### PR TITLE
update config to include the stateChainGateway

### DIFF
--- a/config/berghain.json
+++ b/config/berghain.json
@@ -83,6 +83,10 @@
       {
         "alias": "vault",
         "address": "0xF5e10380213880111522dd0efD3dbb45b9f62Bcc"
+      },
+      {
+        "alias": "state-chain-gateway",
+        "address": "0x6995Ab7c4D7F4B03f467Cf4c8E920427d9621DBd"
       }
     ],
     "tokens": [


### PR DESCRIPTION
Adding the stateChainGateway address to the wallets in the config so that we can have its FLIP balance exported as a metric