### PR TITLE
Feature/pla 1066 add witness count

### DIFF
--- a/src/metrics/chainflip/gaugeWitness.ts
+++ b/src/metrics/chainflip/gaugeWitness.ts
@@ -88,39 +88,27 @@ export const gaugeWitness = async (context: Context): Promise<void> => {
                         witnessHashEth.add(blakeHash);
                     }
                     // TODO: fix btc chainTracking, hash returned is not correct
-                    // if(callData && callData.section === 'bitcoinChainTracking'){
-                    //     console.log("BITCOIN")
-                    //     console.log(callData)
-                    //     console.log(index, ex.toJSON())
+                    if(callData && callData.section === 'bitcoinChainTracking'){
+                        const finalData = callData.args
 
-                    //     // console.log(callData)
-                    //     const finalData = callData.args
-                    //     console.log(finalData)
-                    //     console.log(finalData.new_chain_state.trackedData)
+                        const blockHeight = finalData.new_chain_state.blockHeight.replace(/,/g, '');
+                        // parse the data and removed useless comas (damn polkadot api)
+                        finalData.new_chain_state.blockHeight = blockHeight;
 
-                    //     const blockHeight = finalData.new_chain_state.blockHeight.replace(/,/g, '');
-                    //     // parse the data and removed useless comas (damn polkadot api)
-                    //     finalData.new_chain_state.blockHeight = blockHeight;
+                        // remove all the fees, we don't keep them into account for btc
+                        finalData.new_chain_state.trackedData.btcFeeInfo = {
+                            feePerInputUtxo: '7500',
+                            feePerOutputUtxo: '4300',
+                            minFeeRequiredPerTx: '1200',
+                        };
 
-                    //     // remove all the fees, we don't keep them into account for btc
-                    //     finalData.new_chain_state.trackedData.btcFeeInfo = {
-                    //         feePerInputUtxo: '0',
-                    //         feePerOutputUtxo: '0',
-                    //         minFeeRequiredPerTx: '0',
-                    //     };
+                        // create the extrinsic we need to witness (ETH chain tracking in this case)
+                        const extrinsic = api.tx.bitcoinChainTracking.updateChainState(finalData.new_chain_state)
 
-                    //     // create the extrinsic we need to witness (ETH chain tracking in this case)
-                    //     const extrinsic = api.tx.bitcoinChainTracking.updateChainState(finalData.new_chain_state)
-                    //     console.log(extrinsic.toHuman())
-                    //     console.log(extrinsic.toHuman().method)
-                    //     console.log(extrinsic.toHuman().method.args.new_chain_state)
-
-                    //     // obtain the hash of the extrinsic call
-                    //     const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                    //     console.log(blakeHash)
-
-                    //     witnessHashBtc.add(blakeHash);
-                    // }
+                        // obtain the hash of the extrinsic call
+                        const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
+                        witnessHashBtc.add(blakeHash);
+                    }
 
                     if (callData && callData.section === 'polkadotChainTracking') {
                         const finalData = callData.args;

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -21,7 +21,6 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
         metricFailure.labels({ metric: metricName }).set(0);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
-            console.log(witnessHash)
             for (const elem of witnessHash) {
                 if (signedBlock.block.header.number - elem[0] > 5) {
                     for (const hash of elem[1]) {

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -20,8 +20,6 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
         if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
         metricFailure.labels({ metric: metricName }).set(0);
-        console.log(witnessHash10.size);
-        console.log(witnessHash50.size);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
             for (const elem of witnessHash10) {

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -45,7 +45,9 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                     witnessHash.delete(elem[0]);
                 }
             }
-
+            let btcBlock = 0;
+            let ethBlock = 0;
+            let dotBlock = 0;
             signedBlock.block.extrinsics.forEach((ex: any, index: any) => {
                 const blockNumber: number = Number(signedBlock.block.header.number);
                 if (ex.toHuman().method.method === 'witnessAtEpoch') {
@@ -69,25 +71,36 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if (witnessHash.has(blockNumber)) {
-                            witnessHash.get(blockNumber)?.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                        } else {
-                            const tmpSet = new Set<string>();
-                            tmpSet.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                            witnessHash.set(blockNumber, tmpSet);
+                        if( blockHeight > ethBlock) {
+                            if (witnessHash.has(blockNumber)) {
+                                let set = witnessHash.get(blockNumber);
+                                //if it has already elements we need to check and delete the one sharing the chainTracking
+                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach(elem => {
+                                    let parsedObj = JSON.parse(elem);
+                                    if(parsedObj.type === "ethereumChainTracking:updateChainState") {
+                                        witnessHash.get(blockNumber)?.delete(elem);
+                                    }
+                                })
+                                set?.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                            } else {
+                                const tmpSet = new Set<string>();
+                                tmpSet.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                                witnessHash.set(blockNumber, tmpSet);
+                            }
+                            ethBlock = blockHeight;
                         }
                     }
-                    // TODO: fix btc chainTracking, hash returned is not correct
                     if (callData && callData.section === 'bitcoinChainTracking') {
                         const finalData = callData.args;
 
@@ -109,22 +122,34 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if (witnessHash.has(blockNumber)) {
-                            witnessHash.get(blockNumber)?.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                        } else {
-                            const tmpSet = new Set<string>();
-                            tmpSet.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                            witnessHash.set(blockNumber, tmpSet);
+                        if( blockHeight > btcBlock) {
+                            if (witnessHash.has(blockNumber)) {
+                                let set = witnessHash.get(blockNumber);
+                                //if it has already elements we need to check and delete the one sharing the chainTracking
+                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach(elem => {
+                                    let parsedObj = JSON.parse(elem);
+                                    if(parsedObj.type === "bitcoinChainTracking:updateChainState") {
+                                        witnessHash.get(blockNumber)?.delete(elem);
+                                    }
+                                })
+                                set?.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                            } else {
+                                const tmpSet = new Set<string>();
+                                tmpSet.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                                witnessHash.set(blockNumber, tmpSet);
+                            }
+                            btcBlock = blockHeight;
                         }
                     }
                     if (callData && callData.section === 'polkadotChainTracking') {
@@ -147,22 +172,34 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if (witnessHash.has(blockNumber)) {
-                            witnessHash.get(blockNumber)?.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                        } else {
-                            const tmpSet = new Set<string>();
-                            tmpSet.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: blakeHash,
-                                }),
-                            );
-                            witnessHash.set(blockNumber, tmpSet);
+                        if( blockHeight > dotBlock) {
+                            if (witnessHash.has(blockNumber)) {
+                                let set = witnessHash.get(blockNumber);
+                                //if it has already elements we need to check and delete the one sharing the chainTracking
+                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach(elem => {
+                                    let parsedObj = JSON.parse(elem);
+                                    if(parsedObj.type === "polkadotChainTracking:updateChainState") {
+                                        witnessHash.get(blockNumber)?.delete(elem);
+                                    }
+                                })
+                                set?.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                            } else {
+                                const tmpSet = new Set<string>();
+                                tmpSet.add(
+                                    JSON.stringify({
+                                        type: `${callData.section}:${callData.method}`,
+                                        hash: blakeHash,
+                                    }),
+                                );
+                                witnessHash.set(blockNumber, tmpSet);
+                            }
+                            dotBlock = blockHeight;
                         }
                     }
                 }

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -9,7 +9,7 @@ const witnessHashDot = new Set<any>();
 const metricName: string = 'cf_chain_tracking_witness_count';
 const metric: Gauge = new promClient.Gauge({
     name: metricName,
-    help: 'Is the Network in a rotation',
+    help: 'Number of validator witnessing ChainStateUpdated for an external chain',
     labelNames: ['chain'],
     registers: [],
 });
@@ -88,8 +88,8 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         witnessHashEth.add(blakeHash);
                     }
                     // TODO: fix btc chainTracking, hash returned is not correct
-                    if(callData && callData.section === 'bitcoinChainTracking'){
-                        const finalData = callData.args
+                    if (callData && callData.section === 'bitcoinChainTracking') {
+                        const finalData = callData.args;
 
                         const blockHeight = finalData.new_chain_state.blockHeight.replace(/,/g, '');
                         // parse the data and removed useless comas (damn polkadot api)
@@ -103,7 +103,9 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         };
 
                         // create the extrinsic we need to witness (ETH chain tracking in this case)
-                        const extrinsic = api.tx.bitcoinChainTracking.updateChainState(finalData.new_chain_state)
+                        const extrinsic = api.tx.bitcoinChainTracking.updateChainState(
+                            finalData.new_chain_state,
+                        );
 
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -37,9 +37,8 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                             metric.labels(parsedObj.type, '10').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
-                                console.log(`${parsedObj.type} after 10 blocks`);
-                                console.log(
-                                    `${parsedObj.hash} witnesssed by ${number} validators!`,
+                                logger.info(
+                                    `${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
                                 );
                             }
                         }
@@ -61,9 +60,8 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                             metric.labels(parsedObj.type, '50').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
-                                console.log(`${parsedObj.type} after 50 blocks`);
-                                console.log(
-                                    `${parsedObj.hash} witnesssed by ${number} validators!`,
+                                logger.info(
+                                    `${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
                                 );
                             }
                         }

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -69,11 +69,12 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if(witnessHash.has(blockNumber)){
-                            witnessHash.get(blockNumber)?.add(JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                                })
+                        if (witnessHash.has(blockNumber)) {
+                            witnessHash.get(blockNumber)?.add(
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
                             );
                         } else {
                             const tmpSet = new Set<string>();
@@ -108,11 +109,12 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if(witnessHash.has(blockNumber)){
-                            witnessHash.get(blockNumber)?.add(JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                                })
+                        if (witnessHash.has(blockNumber)) {
+                            witnessHash.get(blockNumber)?.add(
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
                             );
                         } else {
                             const tmpSet = new Set<string>();
@@ -145,11 +147,12 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if(witnessHash.has(blockNumber)){
-                            witnessHash.get(blockNumber)?.add(JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                                })
+                        if (witnessHash.has(blockNumber)) {
+                            witnessHash.get(blockNumber)?.add(
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
                             );
                         } else {
                             const tmpSet = new Set<string>();

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -95,7 +95,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         // parse the data and removed useless comas (damn polkadot api)
                         finalData.new_chain_state.blockHeight = blockHeight;
 
-                        // remove all the fees, we don't keep them into account for btc
+                        // set the default value for the fees (we use these values to witness)
                         finalData.new_chain_state.trackedData.btcFeeInfo = {
                             feePerInputUtxo: '7500',
                             feePerOutputUtxo: '4300',

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -20,8 +20,8 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
         if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
         metricFailure.labels({ metric: metricName }).set(0);
-        console.log(witnessHash10.size)
-        console.log(witnessHash50.size)
+        console.log(witnessHash10.size);
+        console.log(witnessHash50.size);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
             for (const elem of witnessHash10) {
@@ -99,14 +99,24 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
                         if (blockHeight > ethBlock) {
-                            insertOrReplace(witnessHash10, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
-                            insertOrReplace(witnessHash50, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
+                            insertOrReplace(
+                                witnessHash10,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
+                            insertOrReplace(
+                                witnessHash50,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
                             ethBlock = blockHeight;
                         }
                     }
@@ -132,14 +142,24 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
                         if (blockHeight > btcBlock) {
-                            insertOrReplace(witnessHash10, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
-                            insertOrReplace(witnessHash50, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
+                            insertOrReplace(
+                                witnessHash10,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
+                            insertOrReplace(
+                                witnessHash50,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
                             btcBlock = blockHeight;
                         }
                     }
@@ -164,14 +184,24 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
                         if (blockHeight > dotBlock) {
-                            insertOrReplace(witnessHash10, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
-                            insertOrReplace(witnessHash50, JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: blakeHash,
-                            }), blockNumber, `${callData.section}:${callData.method}`);
+                            insertOrReplace(
+                                witnessHash10,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
+                            insertOrReplace(
+                                witnessHash50,
+                                JSON.stringify({
+                                    type: `${callData.section}:${callData.method}`,
+                                    hash: blakeHash,
+                                }),
+                                blockNumber,
+                                `${callData.section}:${callData.method}`,
+                            );
                             dotBlock = blockHeight;
                         }
                     }
@@ -184,28 +214,26 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
     }
 };
 
-function insertOrReplace(map: Map<number, Set<string>>, elem: string, blockNumber: number, callData: string) {
+function insertOrReplace(
+    map: Map<number, Set<string>>,
+    elem: string,
+    blockNumber: number,
+    callData: string,
+) {
     if (map.has(blockNumber)) {
         const set = map.get(blockNumber);
         // if it has already elements we need to check and delete the one sharing the chainTracking
         // we want only 1 extrinsic for each chain max (the one with the latest block reported)
         set?.forEach((element) => {
             const parsedObj = JSON.parse(element);
-            if (
-                parsedObj.type === callData
-            ) {
+            if (parsedObj.type === callData) {
                 set?.delete(element);
             }
         });
-        set?.add(
-            elem,
-        );
-        
+        set?.add(elem);
     } else {
         const tmpSet = new Set<string>();
-        tmpSet.add(
-            elem,
-        );
+        tmpSet.add(elem);
         map.set(blockNumber, tmpSet);
     }
 }

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -71,17 +71,19 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if( blockHeight > ethBlock) {
+                        if (blockHeight > ethBlock) {
                             if (witnessHash.has(blockNumber)) {
-                                let set = witnessHash.get(blockNumber);
-                                //if it has already elements we need to check and delete the one sharing the chainTracking
-                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
-                                set?.forEach(elem => {
-                                    let parsedObj = JSON.parse(elem);
-                                    if(parsedObj.type === "ethereumChainTracking:updateChainState") {
+                                const set = witnessHash.get(blockNumber);
+                                // if it has already elements we need to check and delete the one sharing the chainTracking
+                                // we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach((elem) => {
+                                    const parsedObj = JSON.parse(elem);
+                                    if (
+                                        parsedObj.type === 'ethereumChainTracking:updateChainState'
+                                    ) {
                                         witnessHash.get(blockNumber)?.delete(elem);
                                     }
-                                })
+                                });
                                 set?.add(
                                     JSON.stringify({
                                         type: `${callData.section}:${callData.method}`,
@@ -122,17 +124,19 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if( blockHeight > btcBlock) {
+                        if (blockHeight > btcBlock) {
                             if (witnessHash.has(blockNumber)) {
-                                let set = witnessHash.get(blockNumber);
-                                //if it has already elements we need to check and delete the one sharing the chainTracking
-                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
-                                set?.forEach(elem => {
-                                    let parsedObj = JSON.parse(elem);
-                                    if(parsedObj.type === "bitcoinChainTracking:updateChainState") {
+                                const set = witnessHash.get(blockNumber);
+                                // if it has already elements we need to check and delete the one sharing the chainTracking
+                                // we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach((elem) => {
+                                    const parsedObj = JSON.parse(elem);
+                                    if (
+                                        parsedObj.type === 'bitcoinChainTracking:updateChainState'
+                                    ) {
                                         witnessHash.get(blockNumber)?.delete(elem);
                                     }
-                                })
+                                });
                                 set?.add(
                                     JSON.stringify({
                                         type: `${callData.section}:${callData.method}`,
@@ -172,17 +176,19 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         );
                         // obtain the hash of the extrinsic call
                         const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
-                        if( blockHeight > dotBlock) {
+                        if (blockHeight > dotBlock) {
                             if (witnessHash.has(blockNumber)) {
-                                let set = witnessHash.get(blockNumber);
-                                //if it has already elements we need to check and delete the one sharing the chainTracking
-                                //we want only 1 extrinsic for each chain max (the one with the latest block reported)
-                                set?.forEach(elem => {
-                                    let parsedObj = JSON.parse(elem);
-                                    if(parsedObj.type === "polkadotChainTracking:updateChainState") {
+                                const set = witnessHash.get(blockNumber);
+                                // if it has already elements we need to check and delete the one sharing the chainTracking
+                                // we want only 1 extrinsic for each chain max (the one with the latest block reported)
+                                set?.forEach((elem) => {
+                                    const parsedObj = JSON.parse(elem);
+                                    if (
+                                        parsedObj.type === 'polkadotChainTracking:updateChainState'
+                                    ) {
                                         witnessHash.get(blockNumber)?.delete(elem);
                                     }
-                                })
+                                });
                                 set?.add(
                                     JSON.stringify({
                                         type: `${callData.section}:${callData.method}`,

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -1,6 +1,7 @@
 import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
 import { blake2AsHex } from '@polkadot/util-crypto';
+import { hex2bin, insertOrReplace } from '../../utils/utils';
 
 const witnessHash10 = new Map<number, Set<string>>();
 const witnessHash50 = new Map<number, Set<string>>();
@@ -211,88 +212,3 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
         }
     }
 };
-
-function insertOrReplace(
-    map: Map<number, Set<string>>,
-    elem: string,
-    blockNumber: number,
-    callData: string,
-) {
-    if (map.has(blockNumber)) {
-        const set = map.get(blockNumber);
-        // if it has already elements we need to check and delete the one sharing the chainTracking
-        // we want only 1 extrinsic for each chain max (the one with the latest block reported)
-        set?.forEach((element) => {
-            const parsedObj = JSON.parse(element);
-            if (parsedObj.type === callData) {
-                set?.delete(element);
-            }
-        });
-        set?.add(elem);
-    } else {
-        const tmpSet = new Set<string>();
-        tmpSet.add(elem);
-        map.set(blockNumber, tmpSet);
-    }
-}
-
-function hex2bin(hex: string) {
-    hex = hex.replace('0x', '').toLowerCase();
-    var out = '';
-    for (var c of hex) {
-        switch (c) {
-            case '0':
-                out += '0000';
-                break;
-            case '1':
-                out += '0001';
-                break;
-            case '2':
-                out += '0010';
-                break;
-            case '3':
-                out += '0011';
-                break;
-            case '4':
-                out += '0100';
-                break;
-            case '5':
-                out += '0101';
-                break;
-            case '6':
-                out += '0110';
-                break;
-            case '7':
-                out += '0111';
-                break;
-            case '8':
-                out += '1000';
-                break;
-            case '9':
-                out += '1001';
-                break;
-            case 'a':
-                out += '1010';
-                break;
-            case 'b':
-                out += '1011';
-                break;
-            case 'c':
-                out += '1100';
-                break;
-            case 'd':
-                out += '1101';
-                break;
-            case 'e':
-                out += '1110';
-                break;
-            case 'f':
-                out += '1111';
-                break;
-            default:
-                return '';
-        }
-    }
-
-    return out;
-}

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -16,7 +16,7 @@ const metric: Gauge = new promClient.Gauge({
 
 export const gaugeWitnessChainTracking = async (context: Context): Promise<void> => {
     if (global.epochIndex) {
-        const { logger, api, registry, metricFailure, header } = context;
+        const { logger, api, registry, metricFailure } = context;
         logger.debug(`Scraping ${metricName}`);
 
         if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -14,7 +14,7 @@ const metric: Gauge = new promClient.Gauge({
     registers: [],
 });
 
-export const gaugeWitness = async (context: Context): Promise<void> => {
+export const gaugeWitnessChainTracking = async (context: Context): Promise<void> => {
     if (global.epochIndex) {
         const { logger, api, registry, metricFailure, header } = context;
         logger.debug(`Scraping ${metricName}`);

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -4,7 +4,6 @@ import { Context } from '../../lib/interfaces';
 const witnessHash10 = new Map<number, Set<string>>();
 const witnessHash50 = new Map<number, Set<string>>();
 
-
 const metricName: string = 'cf_witness_count';
 const metric: Gauge = new promClient.Gauge({
     name: metricName,
@@ -33,7 +32,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         if (votes) {
                             const binary = hex2bin(votes);
                             const number = binary.match(/1/g)?.length || 0;
-                            metric.labels(parsedObj.type, "10").set(number);
+                            metric.labels(parsedObj.type, '10').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
                                 console.log(`${parsedObj.type} after 10 blocks`);
@@ -56,7 +55,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         if (votes) {
                             const binary = hex2bin(votes);
                             const number = binary.match(/1/g)?.length || 0;
-                            metric.labels(parsedObj.type, "50").set(number);
+                            metric.labels(parsedObj.type, '50').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
                                 console.log(`${parsedObj.type} after 50 blocks`);

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -36,9 +36,8 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                             metric.labels(parsedObj.type, '10').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
-                                console.log(`${parsedObj.type} after 10 blocks`);
-                                console.log(
-                                    `${parsedObj.hash} witnesssed by ${number} validators!`,
+                                logger.info(
+                                    `${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
                                 );
                             }
                         }
@@ -59,9 +58,8 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                             metric.labels(parsedObj.type, '50').set(number);
                             // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
                             if (number < 150) {
-                                console.log(`${parsedObj.type} after 50 blocks`);
-                                console.log(
-                                    `${parsedObj.hash} witnesssed by ${number} validators!`,
+                                logger.info(
+                                    `${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
                                 );
                             }
                         }

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -1,0 +1,142 @@
+import promClient, { Gauge } from 'prom-client';
+import { Context } from '../../lib/interfaces';
+import { blake2AsHex } from '@polkadot/util-crypto';
+
+const witnessHash = new Map<number, Set<string>>();
+type innerCall = {
+    type: string,
+    hash: string,
+}
+
+const metricName: string = 'cf_witness_count';
+const metric: Gauge = new promClient.Gauge({
+    name: metricName,
+    help: 'Is the Network in a rotation',
+    labelNames: ['extrinsic'],
+    registers: [],
+});
+
+export const gaugeWitnessCount = async (context: Context): Promise<void> => {
+    if (global.epochIndex) {
+        const { logger, api, registry, metricFailure, header } = context;
+        console.log("\n\n")
+        logger.debug(`Scraping ${metricName}`);
+
+        if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+        metricFailure.labels({ metric: metricName }).set(0);
+        try {
+
+            const signedBlock = await api.rpc.chain.getBlock();
+
+            for (const elem of witnessHash){
+                if(signedBlock.block.header.number - elem[0] > 3){
+                    console.log(Number(signedBlock.block.header.number))
+                    // console.log(elem);
+                    console.log(elem[0]) //key  = blockNumber
+                    // console.log(elem[1]) //set containing the hashes
+                    for (const hash of elem[1]){
+                        let parsedObj = JSON.parse(hash)
+                        const votes: string = (
+                            await api.query.witnesser.votes(global.epochIndex, parsedObj.hash)
+                        ).toHuman();
+                        if(votes) {
+                            console.log(parsedObj)
+                            console.log(votes)
+                            const binary = hex2bin(votes);
+                            const number = binary.match(/1/g)?.length;
+                            console.log(number)
+                        }
+                    }
+                    witnessHash.delete(elem[0]);
+                }
+            }
+            // console.log(witnessHash)
+            signedBlock.block.extrinsics.forEach((ex: any, index: any) => {
+                const blockNumber:number = Number(signedBlock.block.header.number);
+                // console.log(blockNumber)
+                if (ex.toHuman().method.method === 'witnessAtEpoch') {
+                    const callData = ex.toHuman().method.args.call;
+                    // console.log(callData)
+                    if(callData.method != "updateChainState"){
+                        // console.log(callData)
+                        // console.log('\n\n');
+                        // console.log(callData)
+                        // console.log(ex.method.args[0].hash.toHex())
+                        const hashToCheck = ex.method.args[0].hash.toHex();
+                        if(witnessHash.has(blockNumber)){
+                            witnessHash.get(blockNumber).add(JSON.stringify({type: callData.section + ":" + callData.method, hash: hashToCheck}));
+                        } else {
+                            let tmpSet = new Set<string>();
+                            tmpSet.add(JSON.stringify({type: callData.section + ":" + callData.method, hash: hashToCheck}))
+                            witnessHash.set(blockNumber, tmpSet);
+                        }
+                    }
+                }
+            });
+        } catch (err) {
+            logger.error(err);
+            metricFailure.labels({ metric: metricName }).set(1);
+        }
+    }
+};
+
+function hex2bin(hex: string) {
+    hex = hex.replace('0x', '').toLowerCase();
+    var out = '';
+    for (var c of hex) {
+        switch (c) {
+            case '0':
+                out += '0000';
+                break;
+            case '1':
+                out += '0001';
+                break;
+            case '2':
+                out += '0010';
+                break;
+            case '3':
+                out += '0011';
+                break;
+            case '4':
+                out += '0100';
+                break;
+            case '5':
+                out += '0101';
+                break;
+            case '6':
+                out += '0110';
+                break;
+            case '7':
+                out += '0111';
+                break;
+            case '8':
+                out += '1000';
+                break;
+            case '9':
+                out += '1001';
+                break;
+            case 'a':
+                out += '1010';
+                break;
+            case 'b':
+                out += '1011';
+                break;
+            case 'c':
+                out += '1100';
+                break;
+            case 'd':
+                out += '1101';
+                break;
+            case 'e':
+                out += '1110';
+                break;
+            case 'f':
+                out += '1111';
+                break;
+            default:
+                return '';
+        }
+    }
+
+    return out;
+}

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -2,10 +2,6 @@ import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
 
 const witnessHash = new Map<number, Set<string>>();
-type innerCall = {
-    type: string;
-    hash: string;
-};
 
 const metricName: string = 'cf_witness_count';
 const metric: Gauge = new promClient.Gauge({

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -1,5 +1,6 @@
 import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
+import { hex2bin, insertOrReplace } from '../../utils/utils';
 
 const witnessHash10 = new Map<number, Set<string>>();
 const witnessHash50 = new Map<number, Set<string>>();
@@ -75,30 +76,24 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                     const callData = ex.toHuman().method.args.call;
                     if (callData.method !== 'updateChainState') {
                         const hashToCheck = ex.method.args[0].hash.toHex();
-                        if (witnessHash10.has(blockNumber)) {
-                            witnessHash10.get(blockNumber)?.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: hashToCheck,
-                                }),
-                            );
-                            witnessHash50.get(blockNumber)?.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: hashToCheck,
-                                }),
-                            );
-                        } else {
-                            const tmpSet = new Set<string>();
-                            tmpSet.add(
-                                JSON.stringify({
-                                    type: `${callData.section}:${callData.method}`,
-                                    hash: hashToCheck,
-                                }),
-                            );
-                            witnessHash10.set(blockNumber, tmpSet);
-                            witnessHash50.set(blockNumber, tmpSet);
-                        }
+                        insertOrReplace(
+                            witnessHash10,
+                            JSON.stringify({
+                                type: `${callData.section}:${callData.method}`,
+                                hash: hashToCheck,
+                            }),
+                            blockNumber,
+                            ``,
+                        );
+                        insertOrReplace(
+                            witnessHash50,
+                            JSON.stringify({
+                                type: `${callData.section}:${callData.method}`,
+                                hash: hashToCheck,
+                            }),
+                            blockNumber,
+                            ``,
+                        );
                     }
                 }
             });
@@ -108,64 +103,3 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
         }
     }
 };
-
-function hex2bin(hex: string) {
-    hex = hex.replace('0x', '').toLowerCase();
-    var out = '';
-    for (var c of hex) {
-        switch (c) {
-            case '0':
-                out += '0000';
-                break;
-            case '1':
-                out += '0001';
-                break;
-            case '2':
-                out += '0010';
-                break;
-            case '3':
-                out += '0011';
-                break;
-            case '4':
-                out += '0100';
-                break;
-            case '5':
-                out += '0101';
-                break;
-            case '6':
-                out += '0110';
-                break;
-            case '7':
-                out += '0111';
-                break;
-            case '8':
-                out += '1000';
-                break;
-            case '9':
-                out += '1001';
-                break;
-            case 'a':
-                out += '1010';
-                break;
-            case 'b':
-                out += '1011';
-                break;
-            case 'c':
-                out += '1100';
-                break;
-            case 'd':
-                out += '1101';
-                break;
-            case 'e':
-                out += '1110';
-                break;
-            case 'f':
-                out += '1111';
-                break;
-            default:
-                return '';
-        }
-    }
-
-    return out;
-}

--- a/src/metrics/chainflip/index.ts
+++ b/src/metrics/chainflip/index.ts
@@ -25,3 +25,4 @@ export * from './gaugeSwappingQueue';
 export * from './gaugeBtcUtxos';
 export * from './gaugeEpoch';
 export * from './gaugeWitnessChainTracking';
+export * from './gaugeWitnessCount';

--- a/src/metrics/chainflip/index.ts
+++ b/src/metrics/chainflip/index.ts
@@ -24,4 +24,4 @@ export * from './gaugeTssRetryQueues';
 export * from './gaugeSwappingQueue';
 export * from './gaugeBtcUtxos';
 export * from './gaugeEpoch';
-export * from './gaugeWitness';
+export * from './gaugeWitnessChainTracking';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,84 @@
+export function insertOrReplace(
+    map: Map<number, Set<string>>,
+    elem: string,
+    blockNumber: number,
+    callData: string,
+) {
+    if (map.has(blockNumber)) {
+        const set = map.get(blockNumber);
+        // if it has already elements we need to check and delete the one sharing the chainTracking
+        // we want only 1 extrinsic for each chain max (the one with the latest block reported)
+        set?.forEach((element) => {
+            const parsedObj = JSON.parse(element);
+            if (parsedObj.type === callData) {
+                set?.delete(element);
+            }
+        });
+        set?.add(elem);
+    } else {
+        const tmpSet = new Set<string>();
+        tmpSet.add(elem);
+        map.set(blockNumber, tmpSet);
+    }
+}
+
+export function hex2bin(hex: string) {
+    hex = hex.replace('0x', '').toLowerCase();
+    var out = '';
+    for (var c of hex) {
+        switch (c) {
+            case '0':
+                out += '0000';
+                break;
+            case '1':
+                out += '0001';
+                break;
+            case '2':
+                out += '0010';
+                break;
+            case '3':
+                out += '0011';
+                break;
+            case '4':
+                out += '0100';
+                break;
+            case '5':
+                out += '0101';
+                break;
+            case '6':
+                out += '0110';
+                break;
+            case '7':
+                out += '0111';
+                break;
+            case '8':
+                out += '1000';
+                break;
+            case '9':
+                out += '1001';
+                break;
+            case 'a':
+                out += '1010';
+                break;
+            case 'b':
+                out += '1011';
+                break;
+            case 'c':
+                out += '1100';
+                break;
+            case 'd':
+                out += '1101';
+                break;
+            case 'e':
+                out += '1110';
+                break;
+            case 'f':
+                out += '1111';
+                break;
+            default:
+                return '';
+        }
+    }
+
+    return out;
+}

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -27,7 +27,8 @@ import {
     gaugeBtcUtxos,
     gaugePendingBroadcast,
     gaugeEpoch,
-    gaugeWitness,
+    gaugeWitnessChainTracking,
+    gaugeWitnessCount,
 } from '../metrics/chainflip';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { customRpcs } from '../utils/customRpcSpecification';
@@ -94,7 +95,8 @@ async function startWatcher(context: Context) {
         context.api = api;
         await api.rpc.chain.subscribeNewHeads(async (header) => {
             gaugeEpoch(context);
-            gaugeWitness({ ...context, header });
+            gaugeWitnessChainTracking(context);
+            gaugeWitnessCount(context);
             gaugeBitcoinBalance(context);
             gaugeBlockHeight({ ...context, header });
             gaugeAuthorities(context);


### PR DESCRIPTION
With this PR the witnessCount gauge is added which keeps track of how many validator witnessed a witnessAtEpoch extrinsics, this metric doesn't include the chainTracking which is measured in a separate function since we need to change some fields of the inner call in those cases.

We gather all the witnessAtEpoch extrinsics in a block and after a margin of 5 blocks we check how many validators witnessed that specific extrinsic and export it as a metric, if the value is less than 150 we also print the encoded callHash such that it is easy to retrieve if we need it.