### PR TITLE
added fee deficit metric

### DIFF
--- a/src/metrics/chainflip/gaugeFeeDeficit.ts
+++ b/src/metrics/chainflip/gaugeFeeDeficit.ts
@@ -5,7 +5,7 @@ const metricName: string = 'cf_fee_deficit';
 const metric: Gauge = new promClient.Gauge({
     name: metricName,
     help: 'The fee deficit, (witheld fee - fee actually spent)',
-    labelNames: ['chain'],
+    labelNames: ['tracked_chain'],
     registers: [],
 });
 
@@ -28,7 +28,7 @@ export const gaugeFeeDeficit = async (context: Context): Promise<void> => {
             totalSpent += Number(element.toHuman().replace(/,/g, ''));
         });
         const deficitEth = (feeWitheldEth - totalSpent) / 1e18;
-        metric.labels('Ethereum').set(deficitEth);
+        metric.labels('ethereum').set(deficitEth);
 
         // DOT fees balance
         const feeWitheldDot = Number(
@@ -42,7 +42,7 @@ export const gaugeFeeDeficit = async (context: Context): Promise<void> => {
             totalSpent += Number(element.toHuman().replace(/,/g, ''));
         });
         const deficitDot = (feeWitheldDot - totalSpent) / 1e10;
-        metric.labels('Polkadot').set(deficitDot);
+        metric.labels('polkadot').set(deficitDot);
     } catch (err) {
         logger.error(err);
         metricFailure.labels({ metric: metricName }).set(1);

--- a/src/metrics/chainflip/gaugeFeeDeficit.ts
+++ b/src/metrics/chainflip/gaugeFeeDeficit.ts
@@ -1,0 +1,50 @@
+import promClient, { Gauge } from 'prom-client';
+import { Context } from '../../lib/interfaces';
+
+const metricName: string = 'cf_fee_deficit';
+const metric: Gauge = new promClient.Gauge({
+    name: metricName,
+    help: 'The fee deficit, (witheld fee - fee actually spent)',
+    labelNames: ['chain'],
+    registers: [],
+});
+
+export const gaugeFeeDeficit = async (context: Context): Promise<void> => {
+    const { logger, api, registry, metricFailure } = context;
+
+    logger.debug(`Scraping ${metricName}`);
+    metricFailure.labels({ metric: metricName }).set(0);
+    if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+    try {
+        // ETH fees balance
+        const feeWitheldEth = Number(
+            (await api.query.ethereumIngressEgress.withheldTransactionFees('Eth'))
+                .toHuman()
+                .replace(/,/g, ''),
+        );
+        const feeSpentEth = await api.query.ethereumBroadcaster.transactionFeeDeficit.entries();
+        let totalSpent = 0;
+        feeSpentEth.forEach(([key, element]: [any, any]) => {
+            totalSpent += Number(element.toHuman().replace(/,/g, ''));
+        });
+        const deficitEth = (feeWitheldEth - totalSpent) / 1e18;
+        metric.labels('Ethereum').set(deficitEth);
+
+        // DOT fees balance
+        const feeWitheldDot = Number(
+            (await api.query.polkadotIngressEgress.withheldTransactionFees('Dot'))
+                .toHuman()
+                .replace(/,/g, ''),
+        );
+        const feeSpentDot = await api.query.polkadotBroadcaster.transactionFeeDeficit.entries();
+        totalSpent = 0;
+        feeSpentDot.forEach(([key, element]: [any, any]) => {
+            totalSpent += Number(element.toHuman().replace(/,/g, ''));
+        });
+        const deficitDot = (feeWitheldDot - totalSpent) / 1e10;
+        metric.labels('Polkadot').set(deficitDot);
+    } catch (err) {
+        logger.error(err);
+        metricFailure.labels({ metric: metricName }).set(1);
+    }
+};

--- a/src/metrics/chainflip/index.ts
+++ b/src/metrics/chainflip/index.ts
@@ -26,3 +26,4 @@ export * from './gaugeBtcUtxos';
 export * from './gaugeEpoch';
 export * from './gaugeWitnessChainTracking';
 export * from './gaugeWitnessCount';
+export * from './gaugeFeeDeficit';

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -29,6 +29,7 @@ import {
     gaugeEpoch,
     gaugeWitnessChainTracking,
     gaugeWitnessCount,
+    gaugeFeeDeficit,
 } from '../metrics/chainflip';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { customRpcs } from '../utils/customRpcSpecification';
@@ -121,6 +122,7 @@ async function startWatcher(context: Context) {
             gaugePendingBroadcast(context);
             gaugeTssRetryQueues(context);
             // gaugeSwappingQueue(context);
+            gaugeFeeDeficit(context);
 
             metric.set(0);
         });


### PR DESCRIPTION
Adde metric to track the fee deficit of the network, currently it has been added only for dot and eth since for btc is not trivial to get this info (when Martin is back will talk to him on how it can be done for btc)