### PR TITLE
Fix witnessing count

### DIFF
--- a/src/metrics/chainflip/gaugeAuthorities.ts
+++ b/src/metrics/chainflip/gaugeAuthorities.ts
@@ -32,7 +32,8 @@ export const gaugeAuthorities = async (context: Context): Promise<void> => {
 
         currentAuthorities = await api.query.validator.currentAuthorities();
         metric.set(currentAuthorities.toJSON().length);
-
+        global.currentAuthorities = currentAuthorities.toJSON().length;
+        console.log(global.currentAuthorities)
         for (const idSs58 of currentAuthorities.toJSON()) {
             const result = await makeRpcRequest(api, 'account_info_v2', idSs58);
             if (result.is_online) {

--- a/src/metrics/chainflip/gaugeAuthorities.ts
+++ b/src/metrics/chainflip/gaugeAuthorities.ts
@@ -33,7 +33,7 @@ export const gaugeAuthorities = async (context: Context): Promise<void> => {
         currentAuthorities = await api.query.validator.currentAuthorities();
         metric.set(currentAuthorities.toJSON().length);
         global.currentAuthorities = currentAuthorities.toJSON().length;
-        console.log(global.currentAuthorities)
+        console.log(global.currentAuthorities);
         for (const idSs58 of currentAuthorities.toJSON()) {
             const result = await makeRpcRequest(api, 'account_info_v2', idSs58);
             if (result.is_online) {

--- a/src/metrics/chainflip/gaugeAuthorities.ts
+++ b/src/metrics/chainflip/gaugeAuthorities.ts
@@ -33,7 +33,6 @@ export const gaugeAuthorities = async (context: Context): Promise<void> => {
         currentAuthorities = await api.query.validator.currentAuthorities();
         metric.set(currentAuthorities.toJSON().length);
         global.currentAuthorities = currentAuthorities.toJSON().length;
-        console.log(global.currentAuthorities);
         for (const idSs58 of currentAuthorities.toJSON()) {
             const result = await makeRpcRequest(api, 'account_info_v2', idSs58);
             if (result.is_online) {

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -35,7 +35,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes: { toHuman: () => any; }) => {
+                            .then((votes: { toHuman: () => any }) => {
                                 if (global.currentBlock === currentBlockNumber) {
                                     const vote = votes.toHuman();
                                     if (vote) {
@@ -63,7 +63,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes: { toHuman: () => any; }) => {
+                            .then((votes: { toHuman: () => any }) => {
                                 if (global.currentBlock === currentBlockNumber) {
                                     const vote = votes.toHuman();
                                     if (vote) {

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -23,57 +23,63 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
         metricFailure.labels({ metric: metricName }).set(0);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
-            let currentBlockNumber = Number(signedBlock.block.header.number.toHuman().replace(/,/g, ''));
+            const currentBlockNumber = Number(
+                signedBlock.block.header.number.toHuman().replace(/,/g, ''),
+            );
             global.currentBlock = currentBlockNumber;
             for (const [blockNumber, set] of witnessHash10) {
                 if (currentBlockNumber - blockNumber > 10) {
-                    let tmpSet = new Set(set);
+                    const tmpSet = new Set(set);
                     witnessHash10.delete(blockNumber);
                     for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
-                            if(global.currentBlock === currentBlockNumber) {
-                                const vote = votes.toHuman();
-                                if (vote) {
-                                    const binary = hex2bin(vote);
-                                    const number = binary.match(/1/g)?.length || 0;
-        
-                                    metric.labels(parsedObj.type, '10').set(number);
-                                    // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                    if (number < 150) {
-                                        logger.info(
-                                            `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
-                                        );
+                        api.query.witnesser
+                            .votes(global.epochIndex, parsedObj.hash)
+                            .then((votes) => {
+                                if (global.currentBlock === currentBlockNumber) {
+                                    const vote = votes.toHuman();
+                                    if (vote) {
+                                        const binary = hex2bin(vote);
+                                        const number = binary.match(/1/g)?.length || 0;
+
+                                        metric.labels(parsedObj.type, '10').set(number);
+                                        // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                        if (number < 150) {
+                                            logger.info(
+                                                `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
                     }
                 }
             }
             for (const [blockNumber, set] of witnessHash50) {
                 if (currentBlockNumber - blockNumber > 50) {
-                    let tmpSet = new Set(set);
+                    const tmpSet = new Set(set);
                     witnessHash50.delete(blockNumber);
                     for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
-                            if(global.currentBlock === currentBlockNumber) {
-                                const vote = votes.toHuman();
-                                if (vote) {
-                                    const binary = hex2bin(vote);
-                                    const number = binary.match(/1/g)?.length || 0;
-        
-                                    metric.labels(parsedObj.type, '50').set(number);
-                                    // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                    if (number < 150) {
-                                        logger.info(
-                                            `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
-                                        );
+                        api.query.witnesser
+                            .votes(global.epochIndex, parsedObj.hash)
+                            .then((votes) => {
+                                if (global.currentBlock === currentBlockNumber) {
+                                    const vote = votes.toHuman();
+                                    if (vote) {
+                                        const binary = hex2bin(vote);
+                                        const number = binary.match(/1/g)?.length || 0;
+
+                                        metric.labels(parsedObj.type, '50').set(number);
+                                        // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                        if (number < 150) {
+                                            logger.info(
+                                                `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
                     }
                 }
             }

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -35,7 +35,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes) => {
+                            .then((votes: { toHuman: () => any; }) => {
                                 if (global.currentBlock === currentBlockNumber) {
                                     const vote = votes.toHuman();
                                     if (vote) {
@@ -44,7 +44,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
                                         metric.labels(parsedObj.type, '10').set(number);
                                         // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                        if (number < 150) {
+                                        if (number < global.currentAuthorities) {
                                             logger.info(
                                                 `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
                                             );
@@ -63,7 +63,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes) => {
+                            .then((votes: { toHuman: () => any; }) => {
                                 if (global.currentBlock === currentBlockNumber) {
                                     const vote = votes.toHuman();
                                     if (vote) {
@@ -72,7 +72,7 @@ export const gaugeWitnessChainTracking = async (context: Context): Promise<void>
 
                                         metric.labels(parsedObj.type, '50').set(number);
                                         // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                        if (number < 150) {
+                                        if (number < global.currentAuthorities) {
                                             logger.info(
                                                 `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
                                             );

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -33,7 +33,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes) => {
+                            .then((votes: { toHuman: () => any; }) => {
                                 const vote = votes.toHuman();
                                 if (vote) {
                                     const binary = hex2bin(vote);
@@ -41,7 +41,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
 
                                     metric.labels(parsedObj.type, '10').set(number);
                                     // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                    if (number < 150) {
+                                    if (number < global.currentAuthorities) {
                                         logger.info(
                                             `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
                                         );
@@ -59,7 +59,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes) => {
+                            .then((votes: { toHuman: () => any; }) => {
                                 const vote = votes.toHuman();
                                 if (vote) {
                                     const binary = hex2bin(vote);
@@ -67,7 +67,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
 
                                     metric.labels(parsedObj.type, '50').set(number);
                                     // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                    if (number < 150) {
+                                    if (number < global.currentAuthorities) {
                                         logger.info(
                                             `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
                                         );

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -22,52 +22,58 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
         metricFailure.labels({ metric: metricName }).set(0);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
-            let currentBlockNumber = Number(signedBlock.block.header.number.toHuman().replace(/,/g, ''));
+            const currentBlockNumber = Number(
+                signedBlock.block.header.number.toHuman().replace(/,/g, ''),
+            );
             for (const [blockNumber, set] of witnessExtrinsicHash10) {
                 if (currentBlockNumber - blockNumber > 10) {
-                    let tmpSet = new Set(set);
+                    const tmpSet = new Set(set);
                     witnessExtrinsicHash10.delete(blockNumber);
                     for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
-                            const vote = votes.toHuman();
-                            if (vote) {
-                                const binary = hex2bin(vote);
-                                const number = binary.match(/1/g)?.length || 0;
-    
-                                metric.labels(parsedObj.type, '10').set(number);
-                                // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                if (number < 150) {
-                                    logger.info(
-                                        `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
-                                    );
+                        api.query.witnesser
+                            .votes(global.epochIndex, parsedObj.hash)
+                            .then((votes) => {
+                                const vote = votes.toHuman();
+                                if (vote) {
+                                    const binary = hex2bin(vote);
+                                    const number = binary.match(/1/g)?.length || 0;
+
+                                    metric.labels(parsedObj.type, '10').set(number);
+                                    // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                    if (number < 150) {
+                                        logger.info(
+                                            `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
+                                        );
+                                    }
                                 }
-                            }
-                        });
+                            });
                     }
                 }
             }
             for (const [blockNumber, set] of witnessExtrinsicHash50) {
                 if (currentBlockNumber - blockNumber > 50) {
-                    let tmpSet = new Set(set);
+                    const tmpSet = new Set(set);
                     witnessExtrinsicHash50.delete(blockNumber);
                     for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
-                            const vote = votes.toHuman();
-                            if (vote) {
-                                const binary = hex2bin(vote);
-                                const number = binary.match(/1/g)?.length || 0;
-    
-                                metric.labels(parsedObj.type, '50').set(number);
-                                // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                                if (number < 150) {
-                                    logger.info(
-                                        `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
-                                    );
+                        api.query.witnesser
+                            .votes(global.epochIndex, parsedObj.hash)
+                            .then((votes) => {
+                                const vote = votes.toHuman();
+                                if (vote) {
+                                    const binary = hex2bin(vote);
+                                    const number = binary.match(/1/g)?.length || 0;
+
+                                    metric.labels(parsedObj.type, '50').set(number);
+                                    // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                    if (number < 150) {
+                                        logger.info(
+                                            `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
+                                        );
+                                    }
                                 }
-                            }
-                        });
+                            });
                     }
                 }
             }

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -2,8 +2,8 @@ import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
 import { hex2bin, insertOrReplace } from '../../utils/utils';
 
-const witnessHash10 = new Map<number, Set<string>>();
-const witnessHash50 = new Map<number, Set<string>>();
+const witnessExtrinsicHash10 = new Map<number, Set<string>>();
+const witnessExtrinsicHash50 = new Map<number, Set<string>>();
 
 const metricName: string = 'cf_witness_count';
 const metric: Gauge = new promClient.Gauge({
@@ -22,49 +22,53 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
         metricFailure.labels({ metric: metricName }).set(0);
         try {
             const signedBlock = await api.rpc.chain.getBlock();
-
-            for (const elem of witnessHash10) {
-                if (signedBlock.block.header.number - elem[0] > 10) {
-                    for (const hash of elem[1]) {
+            let currentBlockNumber = Number(signedBlock.block.header.number.toHuman().replace(/,/g, ''));
+            for (const [blockNumber, set] of witnessExtrinsicHash10) {
+                if (currentBlockNumber - blockNumber > 10) {
+                    let tmpSet = new Set(set);
+                    witnessExtrinsicHash10.delete(blockNumber);
+                    for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        const votes: string = (
-                            await api.query.witnesser.votes(global.epochIndex, parsedObj.hash)
-                        ).toHuman();
-                        if (votes) {
-                            const binary = hex2bin(votes);
-                            const number = binary.match(/1/g)?.length || 0;
-                            metric.labels(parsedObj.type, '10').set(number);
-                            // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                            if (number < 150) {
-                                logger.info(
-                                    `Block ${elem[0]}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
-                                );
+                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
+                            const vote = votes.toHuman();
+                            if (vote) {
+                                const binary = hex2bin(vote);
+                                const number = binary.match(/1/g)?.length || 0;
+    
+                                metric.labels(parsedObj.type, '10').set(number);
+                                // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                if (number < 150) {
+                                    logger.info(
+                                        `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 10 blocks!`,
+                                    );
+                                }
                             }
-                        }
+                        });
                     }
-                    witnessHash10.delete(elem[0]);
                 }
             }
-            for (const elem of witnessHash50) {
-                if (signedBlock.block.header.number - elem[0] > 50) {
-                    for (const hash of elem[1]) {
+            for (const [blockNumber, set] of witnessExtrinsicHash50) {
+                if (currentBlockNumber - blockNumber > 50) {
+                    let tmpSet = new Set(set);
+                    witnessExtrinsicHash50.delete(blockNumber);
+                    for (const hash of tmpSet) {
                         const parsedObj = JSON.parse(hash);
-                        const votes: string = (
-                            await api.query.witnesser.votes(global.epochIndex, parsedObj.hash)
-                        ).toHuman();
-                        if (votes) {
-                            const binary = hex2bin(votes);
-                            const number = binary.match(/1/g)?.length || 0;
-                            metric.labels(parsedObj.type, '50').set(number);
-                            // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                            if (number < 150) {
-                                logger.info(
-                                    `Block ${elem[0]}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
-                                );
+                        api.query.witnesser.votes(global.epochIndex, parsedObj.hash).then((votes) =>{
+                            const vote = votes.toHuman();
+                            if (vote) {
+                                const binary = hex2bin(vote);
+                                const number = binary.match(/1/g)?.length || 0;
+    
+                                metric.labels(parsedObj.type, '50').set(number);
+                                // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
+                                if (number < 150) {
+                                    logger.info(
+                                        `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnesssed by ${number} validators after 50 blocks!`,
+                                    );
+                                }
                             }
-                        }
+                        });
                     }
-                    witnessHash50.delete(elem[0]);
                 }
             }
             // chech the witnessAtEpoch extrinsics in a block and save the encoded callHash to check later
@@ -75,7 +79,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                     if (callData.method !== 'updateChainState') {
                         const hashToCheck = ex.method.args[0].hash.toHex();
                         insertOrReplace(
-                            witnessHash10,
+                            witnessExtrinsicHash10,
                             JSON.stringify({
                                 type: `${callData.section}:${callData.method}`,
                                 hash: hashToCheck,
@@ -84,7 +88,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                             ``,
                         );
                         insertOrReplace(
-                            witnessHash50,
+                            witnessExtrinsicHash50,
                             JSON.stringify({
                                 type: `${callData.section}:${callData.method}`,
                                 hash: hashToCheck,

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -33,7 +33,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes: { toHuman: () => any; }) => {
+                            .then((votes: { toHuman: () => any }) => {
                                 const vote = votes.toHuman();
                                 if (vote) {
                                     const binary = hex2bin(vote);
@@ -59,7 +59,7 @@ export const gaugeWitnessCount = async (context: Context): Promise<void> => {
                         const parsedObj = JSON.parse(hash);
                         api.query.witnesser
                             .votes(global.epochIndex, parsedObj.hash)
-                            .then((votes: { toHuman: () => any; }) => {
+                            .then((votes: { toHuman: () => any }) => {
                                 const vote = votes.toHuman();
                                 if (vote) {
                                     const binary = hex2bin(vote);

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -55,6 +55,7 @@ declare global {
     var rotationInProgress: boolean;
     var epochIndex: number;
     var dotAggKeyAddress: string;
+    var currentBlock: number;
     interface CustomApiPromise extends ApiPromise {
         rpc: ApiPromise['rpc'] & {
             cf: {
@@ -81,7 +82,7 @@ async function startWatcher(context: Context) {
     if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
     if (registry.getSingleMetric(metricFailureName) === undefined)
         registry.registerMetric(metricFailure);
-
+    global.currentBlock = 0;
     try {
         const provider = new WsProvider(env.CF_WS_ENDPOINT, 5000);
         provider.on('disconnected', async (err) => {

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -56,6 +56,7 @@ declare global {
     var epochIndex: number;
     var dotAggKeyAddress: string;
     var currentBlock: number;
+    var currentAuthorities: number;
     interface CustomApiPromise extends ApiPromise {
         rpc: ApiPromise['rpc'] & {
             cf: {


### PR DESCRIPTION
Start all the request simultaneously to avoid "blocking" the other parts of the code.

If a request completes when we are already analyzing the next block we discard the result (only in case of chainTracking, for all the other extrinsics we are still reporting everything)