### PR TITLE
add FLIP totalSupply, queried from flip contract

### DIFF
--- a/src/metrics/eth/gaugeFlipBalance.ts
+++ b/src/metrics/eth/gaugeFlipBalance.ts
@@ -1,0 +1,33 @@
+import promClient from 'prom-client';
+import { Contract, ethers } from 'ethers';
+import { Context } from '../../lib/interfaces';
+import { EthConfig } from '../../config/interfaces';
+
+const metricName: string = 'eth_flip_total_supply';
+const metric = new promClient.Gauge({
+    name: metricName,
+    help: 'The FLIP total supply register on the FLIP contract',
+    registers: [],
+});
+
+export const gaugeFlipBalance = async (context: Context) => {
+    const { logger, registry, metricFailure } = context;
+    const config = context.config as EthConfig;
+    const contract = context.contract as Contract;
+    try {
+        await contract.deployed();
+
+        logger.debug(`Scraping ${metricName}`);
+
+        if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+
+        const totalSupply = await contract.totalSupply();
+        const metricValue: number = Number(Number(totalSupply) / 10 ** 18);
+
+        metric.set(metricValue);
+        metricFailure.labels({ metric: metricName }).set(0);
+    } catch (error) {
+        logger.error(error);
+        metricFailure.labels({ metric: metricName }).set(1);
+    }
+};

--- a/src/metrics/eth/index.ts
+++ b/src/metrics/eth/index.ts
@@ -4,3 +4,4 @@ export * from './gaugeTokenBalance';
 export * from './gaugeBlockHeight';
 export * from './gaugeBlockTime';
 export * from './gaugeReorgSize';
+export * from './gaugeFlipBalance';

--- a/src/watchers/ethereum.ts
+++ b/src/watchers/ethereum.ts
@@ -15,6 +15,7 @@ import {
     gaugeTokenBalance,
     gaugeBlockTime,
     gaugeReorgSize,
+    gaugeFlipBalance,
 } from '../metrics/eth';
 
 const metricName: string = 'eth_watcher_failure';
@@ -115,11 +116,12 @@ async function startWatcher(context: Context) {
         context.provider = wsProvider;
 
         wsProvider.on('block', async (blockNumber: number) => {
-            await gaugeEthBalance(context);
-            await gaugeTokenBalance({ ...context, contract: flipContract }, 'FLIP');
-            await gaugeTokenBalance({ ...context, contract: usdcContract }, 'USDC');
-            await gaugeBlockHeight({ ...context, blockNumber });
-            await gaugeBlockTime({ ...context, blockNumber });
+            gaugeEthBalance(context);
+            gaugeTokenBalance({ ...context, contract: flipContract }, 'FLIP');
+            gaugeTokenBalance({ ...context, contract: usdcContract }, 'USDC');
+            gaugeBlockHeight({ ...context, blockNumber });
+            gaugeBlockTime({ ...context, blockNumber });
+            gaugeFlipBalance({ ...context, contract: flipContract });
             // await gaugeReorgSize({...context, blockNumber}); //TODO fix metric
         });
 


### PR DESCRIPTION
Add FLIP total supply metric (coming from the FLIP contract on eth)

We can now use this new metric and cf_total_flip_supply (coming from the state-chain) to check if the balance discrepancy is low enough (we update the total supply on eth once a day). This new alarm will fire if the discrepancy grow too much, meaning there could be some exploit going on which allows people to mint new FLIP only on ETH/state-chain