### PR TITLE
fix: remove rounding

### DIFF
--- a/src/metrics/chainflip/gaugePriceDelta.ts
+++ b/src/metrics/chainflip/gaugePriceDelta.ts
@@ -153,7 +153,7 @@ export const gaugePriceDelta = async (context: Context): Promise<void> => {
     }
 
     function calculateRateToUsdc(from: asset, intialAmount: number) {
-        const labelAmount = Math.round(intialAmount / decimals[from.asset]).toString();
+        const labelAmount = (intialAmount / decimals[from.asset]).toString();
         // we need to subtract ingress fee before calculating the swap rate
         let netImputAmount =
             intialAmount / decimals[from.asset] -


### PR DESCRIPTION
Removed Math.round from labelAmount -> labelAmount doesn't need to be rounded (it can be a float, there is no point in rounding it and lose precision)