### PR TITLE
add mapping for errors

### DIFF
--- a/src/metrics/chainflip/countEvents.ts
+++ b/src/metrics/chainflip/countEvents.ts
@@ -61,9 +61,9 @@ export const countEvents = async (context: Context): Promise<void> => {
 
         if (config.eventLog) {
             if (event.data.dispatchError) {
-                const metadata = errorMap.get(event.data.dispatchError.toString())
-                    ? errorMap.get(event.data.dispatchError.toString())
-                    : 'Error mapping not defined';
+                const metadata = errorMap.has(event.data.dispatchError.toString())
+                    ? { error: errorMap.get(event.data.dispatchError.toString()) }
+                    : { error: 'Error mapping not defined' };
                 logger.info('event_log', {
                     metadata,
                     event: `${event.section}:${event.method}`,

--- a/src/metrics/chainflip/countEvents.ts
+++ b/src/metrics/chainflip/countEvents.ts
@@ -27,6 +27,12 @@ const metricSlash: Counter = new promClient.Counter({
     registers: [],
 });
 
+const errorMap = new Map();
+errorMap.set(
+    `{"module":{"index":35,"error":"0x03000000"}}`,
+    'liquidityPools.UnspecifiedOrderPrice',
+);
+
 export const countEvents = async (context: Context): Promise<void> => {
     const { logger, registry, events, api } = context;
     const config = context.config as FlipConfig;
@@ -54,10 +60,21 @@ export const countEvents = async (context: Context): Promise<void> => {
         metric.labels(`${event.section}:${event.method}`).inc(1);
 
         if (config.eventLog) {
-            logger.info('event_log', {
-                event: `${event.section}:${event.method}`,
-                data: event.data.toHuman(),
-            });
+            if (event.data.dispatchError) {
+                const metadata = errorMap.get(event.data.dispatchError.toString())
+                    ? errorMap.get(event.data.dispatchError.toString())
+                    : 'Error mapping not defined';
+                logger.info('event_log', {
+                    metadata,
+                    event: `${event.section}:${event.method}`,
+                    data: event.data.toHuman(),
+                });
+            } else {
+                logger.info('event_log', {
+                    event: `${event.section}:${event.method}`,
+                    data: event.data.toHuman(),
+                });
+            }
         }
 
         // Set extra labels for specific events


### PR DESCRIPTION
When an extrinsic fails we get back an index and an index error, these aren't very useful in understanding what the actual error is without having to go and check directly in the backend repo.

We create a mapping between the known error codes and the Human Readable version of the Error, adding it to the metadata field of the logs such that we can use that for alerting purposes.