### PR TITLE
Initialize counters value

### DIFF
--- a/src/metrics/chainflip/countEvents.ts
+++ b/src/metrics/chainflip/countEvents.ts
@@ -38,7 +38,30 @@ export const countEvents = async (context: Context): Promise<void> => {
 
     logger.debug(`Scraping ${metricName}`);
 
-    if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+    if (registry.getSingleMetric(metricName) === undefined) {
+        registry.registerMetric(metric);
+        metric.labels("governance:Approved").inc();
+        metric.labels("governance:Executed").inc();
+        metric.labels("governance:Proposed").inc();
+        metric.labels("ethereumBroadcaster:BroadcastAborted").inc();
+        metric.labels("polkadotBroadcaster:BroadcastAborted").inc();
+        metric.labels("arbitrumBroadcaster:BroadcastAborted").inc();
+        metric.labels("bitcoinBroadcaster:BroadcastAborted").inc();
+        metric.labels("solanaBroadcaster:BroadcastAborted").inc();
+        metric.labels("bitcoinBroadcaster:BroadcastAttemptTimeout").inc();
+        metric.labels("ethereumBroadcaster:BroadcastAttemptTimeout").inc();
+        metric.labels("polkadotBroadcaster:BroadcastAttemptTimeout").inc();
+        metric.labels("arbitrumBroadcaster:BroadcastAttemptTimeout").inc();
+        metric.labels("solanaBroadcaster:BroadcastAttemptTimeout").inc();
+        metric.labels("evmThresholdSigner:RetryRequested").inc();
+        metric.labels("bitcoinThresholdSigner:RetryRequested").inc();
+        metric.labels("polkadotThresholdSigner:RetryRequested").inc();
+        metric.labels("solanaThresholdSigner:RetryRequested").inc();
+        metric.labels("evmThresholdSigner:KeygenFailure").inc();
+        metric.labels("bitcoinThresholdSigner:KeygenFailure").inc();
+        metric.labels("polkadotThresholdSigner:KeygenFailure").inc();
+        metric.labels("solanaThresholdSigner:KeygenFailure").inc();
+    }
     if (registry.getSingleMetric(metricExtrinsicFailedName) === undefined)
         registry.registerMetric(metricExtrinsicFailed);
     if (registry.getSingleMetric(metricNameSlashing) === undefined)

--- a/src/metrics/polkadot/countEvents.ts
+++ b/src/metrics/polkadot/countEvents.ts
@@ -20,7 +20,10 @@ export const countEvents = async (context: Context): Promise<void> => {
 
     logger.debug(`Scraping ${metricName}`);
 
-    if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+    if (registry.getSingleMetric(metricName) === undefined) {
+        registry.registerMetric(metric);
+        metric.labels("system:CodeUpdated").inc();
+    }
 
     for (const { event } of events) {
         metric.labels(`${event.section}:${event.method}`).inc(1);


### PR DESCRIPTION
initialize counters to 1 (the one use for alerting) -> counter not initialized aren't capture when using increase(), since their value before initialization is null and not defaulting to 0 (like you would expect)