### PR TITLE
Fix: increase liveness of "support" metrics

### DIFF
--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -155,7 +155,7 @@ function log(
                     validators: `${validators}`,
                     witnessedBy: `${total}`,
                 }),
-                currentBlockNumber + 40,
+                currentBlockNumber + 100,
             );
         }
     }


### PR DESCRIPTION
Increase the window before deleting the metrics containing the list of failing validators so that we can properly reference them when alerting.

(40 -> 100 blocks)