### PR TITLE
pass basic auth through header

### DIFF
--- a/config/sisyphos.json
+++ b/config/sisyphos.json
@@ -122,11 +122,8 @@
     "enabled": true,
     "network": "devnet",
     "defaultMetrics": [],
-    "contracts": [
-
-    ],
-    "wallets": [
-    ],
+    "contracts": [],
+    "wallets": [],
     "skipMetrics": []
   }
 }

--- a/src/metrics/sol/gaugeDurableNonces.ts
+++ b/src/metrics/sol/gaugeDurableNonces.ts
@@ -31,8 +31,8 @@ export const gaugeSolNonces = async (context: Context) => {
             const accountsInfo = await connection.getMultipleAccountsInfo(accounts);
 
             for (let i = 0; i < accounts.length; i++) {
-                if(!accountsInfo[i]) {
-                    continue
+                if (!accountsInfo[i]) {
+                    continue;
                 }
                 if (
                     global.availableSolanaNonces[i].base58nonce !==

--- a/src/metrics/sol/gaugeDurableNonces.ts
+++ b/src/metrics/sol/gaugeDurableNonces.ts
@@ -31,6 +31,9 @@ export const gaugeSolNonces = async (context: Context) => {
             const accountsInfo = await connection.getMultipleAccountsInfo(accounts);
 
             for (let i = 0; i < accounts.length; i++) {
+                if(!accountsInfo[i]) {
+                    continue
+                }
                 if (
                     global.availableSolanaNonces[i].base58nonce !==
                     NonceAccount.fromAccountData(accountsInfo[i].data).nonce

--- a/src/watchers/solana.ts
+++ b/src/watchers/solana.ts
@@ -35,8 +35,12 @@ async function startWatcher(context: Context) {
             registry.registerMetric(metricFailure);
 
         metric.set(0);
-        const provider = new solanaWeb3.Connection(env.SOL_HTTP_ENDPOINT);
-        context.connection = provider;
+        const solanaURL = new URL(env.SOL_HTTP_ENDPOINT);
+        context.connection = new solanaWeb3.Connection(solanaURL.origin, {
+            httpHeaders: {
+                'Authorization': 'Basic ' + Buffer.from(solanaURL.username + ':' + solanaURL.password).toString('base64')
+            }
+        });
 
         pollEndpoint(gaugeSolBalance, context, 6);
         pollEndpoint(gaugeTxOutcome, context, 6);

--- a/src/watchers/solana.ts
+++ b/src/watchers/solana.ts
@@ -38,8 +38,10 @@ async function startWatcher(context: Context) {
         const solanaURL = new URL(env.SOL_HTTP_ENDPOINT);
         context.connection = new solanaWeb3.Connection(solanaURL.origin, {
             httpHeaders: {
-                'Authorization': 'Basic ' + Buffer.from(solanaURL.username + ':' + solanaURL.password).toString('base64')
-            }
+                Authorization:
+                    'Basic ' +
+                    Buffer.from(solanaURL.username + ':' + solanaURL.password).toString('base64'),
+            },
         });
 
         pollEndpoint(gaugeSolBalance, context, 6);


### PR DESCRIPTION
Solana connection doesn't allow to use an endpoint with basic auth in it, it will fail to execute the request.
We handle the case such that if basic auth is used the Connection will be able to execute requests without failing.