### PR TITLE
switch to Gauge for metrics used for alerts

### DIFF
--- a/src/metrics/arb/countContractEvents.ts
+++ b/src/metrics/arb/countContractEvents.ts
@@ -2,7 +2,7 @@ import promClient from 'prom-client';
 import { Context } from '../../lib/interfaces';
 
 const metricName = 'arb_contract_events_count';
-const metric = new promClient.Counter({
+const metric = new promClient.Gauge({
     name: metricName,
     help: 'Total of contract events',
     labelNames: ['event', 'alias'],

--- a/src/metrics/chainflip/eventsRotationInfo.ts
+++ b/src/metrics/chainflip/eventsRotationInfo.ts
@@ -1,6 +1,5 @@
 import promClient, { Counter, Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
-import { FlipConfig } from '../../config/interfaces';
 import makeRpcRequest from '../../utils/makeRpcRequest';
 
 const metricNameRotationPhaseAttempt: string = 'cf_rotation_phase_attempts';

--- a/src/metrics/eth/countContractEvents.ts
+++ b/src/metrics/eth/countContractEvents.ts
@@ -2,13 +2,12 @@ import promClient from 'prom-client';
 import { Context } from '../../lib/interfaces';
 
 const metricName = 'eth_contract_events_count';
-const metric = new promClient.Counter({
+const metric = new promClient.Gauge({
     name: metricName,
     help: 'Total of contract events',
     labelNames: ['event', 'alias'],
     registers: [],
 });
-
 export const countContractEvents = async (context: Context) => {
     if (context.config.skipMetrics.includes('eth_contract_events_count')) {
         return;
@@ -17,7 +16,10 @@ export const countContractEvents = async (context: Context) => {
 
     logger.debug(`Scraping ${metricName}`);
 
-    if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
+    if (registry.getSingleMetric(metricName) === undefined) {
+        registry.registerMetric(metric);
+        metric.labels('FlipSupplyUpdated', 'state-chain-gateway').set(0);
+    }
 
     metric.labels(event, contractAlias).inc(1);
 };

--- a/src/metrics/polkadot/countEvents.ts
+++ b/src/metrics/polkadot/countEvents.ts
@@ -1,10 +1,10 @@
-import promClient, { Counter, Gauge } from 'prom-client';
+import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
 import { DotConfig, FlipConfig } from '../../config/interfaces';
 import { decodeAddress } from '@polkadot/util-crypto';
 
 const metricName: string = 'dot_events_count_total';
-const metric: Counter = new promClient.Counter({
+const metric: Gauge = new promClient.Gauge({
     name: metricName,
     help: 'Count of events on chain',
     labelNames: ['event'],
@@ -22,10 +22,10 @@ export const countEvents = async (context: Context): Promise<void> => {
 
     if (registry.getSingleMetric(metricName) === undefined) {
         registry.registerMetric(metric);
-        metric.labels('system:CodeUpdated').inc();
+        metric.labels('system:CodeUpdated').set(0);
     }
 
     for (const { event } of events) {
-        metric.labels(`${event.section}:${event.method}`).inc(1);
+        metric.labels(`${event.section}:${event.method}`).inc();
     }
 };


### PR DESCRIPTION
- Use Gauges when the metric is used for alerting -> we can set it to 0 as "initialization"
- Add broadcaster label to CCM/non-CCM broadcastAborted so that we can quickly determine which target chain was the broadcast for