### PR TITLE
feat: improvements

### DIFF
--- a/src/metrics/chainflip/countEvents.ts
+++ b/src/metrics/chainflip/countEvents.ts
@@ -91,6 +91,7 @@ export const countEvents = async (context: Context, data: ProtocolData): Promise
         metric.labels('bitcoinChainTracking:ChainStateUpdated').set(0);
         metric.labels('polkadotChainTracking:ChainStateUpdated').set(0);
         metric.labels('arbitrumChainTracking:ChainStateUpdated').set(0);
+        metric.labels('bitcoinIngressEgress:BoostedDepositLost').set(0);
     }
     if (registry.getSingleMetric(metricExtrinsicFailedName) === undefined)
         registry.registerMetric(metricExtrinsicFailed);

--- a/src/metrics/chainflip/gaugeSafeMode.ts
+++ b/src/metrics/chainflip/gaugeSafeMode.ts
@@ -1,0 +1,62 @@
+import promClient, { Gauge } from 'prom-client';
+import { Context } from '../../lib/interfaces';
+import { ProtocolData } from '../../utils/utils';
+import { makeUncheckedRpcRequest } from '../../utils/makeRpcRequest';
+
+const metricNameSafeMode: string = 'cf_safe_mode';
+const metricSafeMode: Gauge = new promClient.Gauge({
+    name: metricNameSafeMode,
+    help: 'The reputation of a validator',
+    labelNames: ['name'],
+    registers: [],
+});
+
+export const gaugeSafeMode = async (context: Context, data: ProtocolData): Promise<void> => {
+    if (context.config.skipMetrics.includes('cf_validator')) {
+        return;
+    }
+    const { logger, apiLatest, registry, metricFailure } = context;
+
+    logger.debug(`Scraping ${metricNameSafeMode}`);
+
+    if (registry.getSingleMetric(metricNameSafeMode) === undefined)
+        registry.registerMetric(metricSafeMode);
+
+    metricFailure.labels({ metric: metricNameSafeMode }).set(0);
+
+    try {
+        const safe_modes = await makeUncheckedRpcRequest(
+            apiLatest,
+            'safe_mode_statuses',
+            context.blockHash,
+        );
+        const flatten = flattenObject(safe_modes);
+        for (const elem of flatten) {
+            if (elem[0] === 'witnesser') {
+                const status = elem[1] === 'CodeGreen' ? 0 : 1;
+                metricSafeMode.labels(elem[0]).set(status);
+            } else {
+                metricSafeMode.labels(elem[0]).set(elem[1] === 'true' ? 1 : 0);
+            }
+        }
+    } catch (e) {
+        metricFailure.labels({ metric: metricNameSafeMode }).set(1);
+    }
+};
+
+function flattenObject(obj: Record<string, unknown>, parentKey = ''): any[] {
+    let result: any[] = [];
+    for (const key in obj) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (obj.hasOwnProperty(key)) {
+            const newKey = parentKey ? `${parentKey}.${key}` : key;
+            if (typeof obj[key] === 'object' && obj[key] !== null) {
+                // @ts-expect-error Ingore
+                result = result.concat(flattenObject(obj[key], newKey));
+            } else {
+                result.push([newKey, obj[key]]);
+            }
+        }
+    }
+    return result;
+}

--- a/src/metrics/chainflip/gaugeSafeMode.ts
+++ b/src/metrics/chainflip/gaugeSafeMode.ts
@@ -6,7 +6,7 @@ import { makeUncheckedRpcRequest } from '../../utils/makeRpcRequest';
 const metricNameSafeMode: string = 'cf_safe_mode';
 const metricSafeMode: Gauge = new promClient.Gauge({
     name: metricNameSafeMode,
-    help: 'The reputation of a validator',
+    help: 'Safe mode enabled for',
     labelNames: ['name'],
     registers: [],
 });

--- a/src/metrics/chainflip/gaugeSafeMode.ts
+++ b/src/metrics/chainflip/gaugeSafeMode.ts
@@ -12,7 +12,7 @@ const metricSafeMode: Gauge = new promClient.Gauge({
 });
 
 export const gaugeSafeMode = async (context: Context, data: ProtocolData): Promise<void> => {
-    if (context.config.skipMetrics.includes('cf_validator')) {
+    if (context.config.skipMetrics.includes('cf_safe_mode')) {
         return;
     }
     const { logger, apiLatest, registry, metricFailure } = context;
@@ -25,12 +25,12 @@ export const gaugeSafeMode = async (context: Context, data: ProtocolData): Promi
     metricFailure.labels({ metric: metricNameSafeMode }).set(0);
 
     try {
-        const safe_modes = await makeUncheckedRpcRequest(
+        const safe_mode = await makeUncheckedRpcRequest(
             apiLatest,
             'safe_mode_statuses',
             context.blockHash,
         );
-        const flatten = flattenObject(safe_modes);
+        const flatten = flattenObject(safe_mode);
         for (const elem of flatten) {
             if (elem[0] === 'witnesser') {
                 const status = elem[1] === 'CodeGreen' ? 0 : 1;

--- a/src/metrics/polkadot/gaugeBlockHeight.ts
+++ b/src/metrics/polkadot/gaugeBlockHeight.ts
@@ -12,11 +12,16 @@ export const gaugeBlockHeight = async (context: Context) => {
     if (context.config.skipMetrics.includes('dot_block_height')) {
         return;
     }
-    const { logger, registry, header } = context;
+    const { logger, api, registry, header } = context;
 
     logger.debug(`Scraping ${metricName}`);
 
     if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
 
-    metric.set(Number(header.number));
+    try {
+        const block = await api.query.system.number();
+        metric.set(block.toJSON());
+    } catch (e) {
+        logger.error(e);
+    }
 };

--- a/src/utils/makeRpcRequest.ts
+++ b/src/utils/makeRpcRequest.ts
@@ -194,6 +194,7 @@ type RpcParamsMap = {
     witness_count: [hash: string, epoch_index?: number, at?: string];
     monitoring_data: [at?: string];
     monitoring_accounts_info: [accounts: string[], at?: string];
+    safe_mode_statuses: [];
 };
 
 type RpcCall = keyof RpcParamsMap & keyof typeof customRpcTypes & keyof typeof customRpcs.cf;
@@ -212,6 +213,14 @@ export default async function makeRpcRequest<M extends RpcCall>(
     return result as RpcReturnValue[M];
 }
 
+export async function makeUncheckedRpcRequest(
+    apiPromise: CustomApiPromise,
+    method: string,
+    ...args: any
+): Promise<any> {
+    const result: any = await apiPromise.rpc(`cf_${method}`, ...args);
+    return result;
+}
 // export async function customRpc<M extends RpcCall>(
 //     apiPromise: CustomApiPromise,
 //     method: M,

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -32,6 +32,7 @@ import makeRpcRequest from '../utils/makeRpcRequest';
 import { gaugeKeyActivationBroadcast } from '../metrics/chainflip/gaugeKeyActivationBroadcast';
 import { ProtocolData } from '../utils/utils';
 import { gaugeOpenElections } from '../metrics/chainflip/gaugeOpenElections';
+import { gaugeSafeMode } from '../metrics/chainflip/gaugeSafeMode';
 
 const metricFailureName: string = 'metric_scrape_failure';
 const metricFailure: promClient.Gauge = new promClient.Gauge({
@@ -102,6 +103,7 @@ async function startWatcher(context: Context) {
             gaugeKeyActivationBroadcast(context, data);
             gaugeSolanaNonces(context, data);
 
+            gaugeSafeMode(context, data);
             gaugeOpenElections(context, data);
             gaugeBlockWeight(context, data);
             countEvents(context, data);

--- a/src/watchers/polkadot.ts
+++ b/src/watchers/polkadot.ts
@@ -2,6 +2,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 import { countEvents, gaugeBlockHeight, gaugeDotBalance } from '../metrics/polkadot';
 import { Context } from '../lib/interfaces';
 import promClient from 'prom-client';
+import { pollEndpoint } from '../utils/utils';
 
 const metricFailureName: string = 'metric_scrape_failure';
 const metricFailure: promClient.Gauge = new promClient.Gauge({
@@ -43,8 +44,9 @@ async function startWatcher(context: Context) {
             noInitWarn: true,
         });
         context.api = api;
+        pollEndpoint(gaugeBlockHeight, context, 5);
+
         await api.rpc.chain.subscribeFinalizedHeads(async (header) => {
-            await gaugeBlockHeight({ ...context, header });
             await gaugeDotBalance(context);
             await countEvents({ ...context, header });
             metric.set(0);


### PR DESCRIPTION
- Initialize label bitcoinIngressEgress:BoostedDepositLost to 0 for gauge cf_events_count (to avoid initial increment)
- add cf_safe_mode() which exposes if safe mode is enable or not (a label name is used to identify which safe mode we are talking about)
- use polling to query the last block height for dot like we do for other chain -> ws seems unreliable
- support api key for btc endpoints