### PR TITLE
feat: reduce liveness of temporary metric

### DIFF
--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -46,7 +46,7 @@ export const startSubscription = async (context: Context) => {
                         metricSolanaTxReverted.labels(log.signature).set(1);
                         setTimeout(() => {
                             metricSolanaTxReverted.remove(log.signature);
-                        }, 600000); // 10m
+                        }, 60000); // 1m
                     }
                 }
             },


### PR DESCRIPTION
Reduce the liveness of `sol_tx_reverted` to 1m such that manually resolvable alert won't keep firing if resolved in the first 10m.