### PR TITLE
feat: create separate metrci for CCM solana tx reverted

### DIFF
--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -67,12 +67,12 @@ export const startSubscription = async (context: Context) => {
                             metricSolanaCCMTxReverted.labels(log.signature).set(1);
                             setTimeout(() => {
                                 metricSolanaTxReverted.remove(log.signature);
-                            }, 600000); // 10m
+                            }, 60000); // 1m
                         } else {
                             metricSolanaTxReverted.labels(log.signature).set(1);
                             setTimeout(() => {
                                 metricSolanaTxReverted.remove(log.signature);
-                            }, 600000); // 10m
+                            }, 60000); // 1m
                         }
                     }
                 }

--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -60,6 +60,7 @@ export const startSubscription = async (context: Context) => {
                     // only report reverted tx if they are originated from our aggKey
                     if (keys[0].toString() === global.solanaCurrentOnChainKey) {
                         if (transaction.transaction.message.instructions.length <= 4) {
+                            // Transfer/fetch
                             metricSolanaTxReverted.labels(log.signature).set(1);
                             setTimeout(() => {
                                 metricSolanaTxReverted.remove(log.signature);
@@ -71,7 +72,14 @@ export const startSubscription = async (context: Context) => {
                                 base58.decode(instruction).slice(0, 8),
                             ).toString('hex');
                             if (ccmInstructions.includes(decoded_instruction)) {
+                                // CCM
                                 metricSolanaCCMTxReverted.labels(log.signature).set(1);
+                                setTimeout(() => {
+                                    metricSolanaTxReverted.remove(log.signature);
+                                }, 60000); // 1m
+                            } else {
+                                // Rotation/Batched fetches
+                                metricSolanaTxReverted.labels(log.signature).set(1);
                                 setTimeout(() => {
                                     metricSolanaTxReverted.remove(log.signature);
                                 }, 60000); // 1m

--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -57,22 +57,25 @@ export const startSubscription = async (context: Context) => {
                         maxSupportedTransactionVersion: 0,
                     });
                     const keys = transaction.transaction.message.accountKeys;
-                    const instruction = transaction.transaction.message.instructions[4].data;
                     // only report reverted tx if they are originated from our aggKey
                     if (keys[0].toString() === global.solanaCurrentOnChainKey) {
-                        const decoded_instruction = Buffer.from(
-                            base58.decode(instruction).slice(0, 8),
-                        ).toString('hex');
-                        if (ccmInstructions.includes(decoded_instruction)) {
-                            metricSolanaCCMTxReverted.labels(log.signature).set(1);
-                            setTimeout(() => {
-                                metricSolanaTxReverted.remove(log.signature);
-                            }, 60000); // 1m
-                        } else {
+                        if (transaction.transaction.message.instructions.length <= 4) {
                             metricSolanaTxReverted.labels(log.signature).set(1);
                             setTimeout(() => {
                                 metricSolanaTxReverted.remove(log.signature);
                             }, 60000); // 1m
+                        } else {
+                            const instruction =
+                                transaction.transaction.message.instructions[4].data;
+                            const decoded_instruction = Buffer.from(
+                                base58.decode(instruction).slice(0, 8),
+                            ).toString('hex');
+                            if (ccmInstructions.includes(decoded_instruction)) {
+                                metricSolanaCCMTxReverted.labels(log.signature).set(1);
+                                setTimeout(() => {
+                                    metricSolanaTxReverted.remove(log.signature);
+                                }, 60000); // 1m
+                            }
                         }
                     }
                 }

--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -1,6 +1,7 @@
 import promClient, { Gauge } from 'prom-client';
 import { Context } from '../../lib/interfaces';
 import { PublicKey, NonceAccount } from '@solana/web3.js';
+import base58 from 'bs58';
 
 const metricSolanaTxRevertedName: string = 'sol_tx_reverted';
 const metricSolanaTxReverted: Gauge = new promClient.Gauge({
@@ -39,8 +40,12 @@ export const startSubscription = async (context: Context) => {
                 if (log.err !== null) {
                     const transaction = await context.connection.getTransaction(log.signature, {
                         commitment: 'finalized',
+                        maxSupportedTransactionVersion: 0,
                     });
+                    //4t5EHJWtGACTXyzT5YC8LDwAuK5iqgXckJz7gaKGBwKkcfuKT1UmCfGZdTVT8GX62oi4xDt9ZXTLbV4t91txdj1k
                     const keys = transaction.transaction.message.accountKeys;
+                    const instruction = transaction.transaction.message.instructions[4].data;
+                    const decoded_instruction = base58.decode(instruction)
                     // only report reverted tx if they are originated from our aggKey
                     if (keys[0].toString() === global.solanaCurrentOnChainKey) {
                         metricSolanaTxReverted.labels(log.signature).set(1);

--- a/src/metrics/sol/startSubscription.ts
+++ b/src/metrics/sol/startSubscription.ts
@@ -75,7 +75,7 @@ export const startSubscription = async (context: Context) => {
                                 // CCM
                                 metricSolanaCCMTxReverted.labels(log.signature).set(1);
                                 setTimeout(() => {
-                                    metricSolanaTxReverted.remove(log.signature);
+                                    metricSolanaCCMTxReverted.remove(log.signature);
                                 }, 60000); // 1m
                             } else {
                                 // Rotation/Batched fetches


### PR DESCRIPTION
Added a separate metric to track TX reverted for solana such that we can separate normal tx from CCM tx