### PR TITLE
feat: remove Btc fee imbalance 

### DIFF
--- a/src/metrics/chainflip/gaugeFeeDeficit.ts
+++ b/src/metrics/chainflip/gaugeFeeDeficit.ts
@@ -56,18 +56,6 @@ export const gaugeFeeDeficit = async (context: Context, data: ProtocolData): Pro
         metric.labels('polkadot').set(metricValue);
     }
 
-    // BTC fees balance
-    const btc_fees = data.data.fee_imbalance.bitcoin;
-    if (Object.hasOwn(btc_fees, 'Deficit')) {
-        // Deficit case
-        const metricValue = -(Number(btc_fees.Deficit) / 1e8);
-        metric.labels('bitcoin').set(metricValue);
-    } else {
-        // Surplus case
-        const metricValue = Number(btc_fees.Surplus) / 1e8;
-        metric.labels('bitcoin').set(metricValue);
-    }
-
     // SOL fees balance
     const sol_fees = data.data.fee_imbalance.solana;
     if (Object.hasOwn(sol_fees, 'Deficit')) {


### PR DESCRIPTION
Fee imbalance for BTC doesn't make sense since this value is not accurate, hence it is better to delete this metric to avoid making wrong assumption based on it later on