### PR TITLE
feat: add oraclePrices metrics

### DIFF
--- a/src/metrics/chainflip/gaugeOraclePrices.ts
+++ b/src/metrics/chainflip/gaugeOraclePrices.ts
@@ -1,0 +1,89 @@
+import promClient, { Gauge } from 'prom-client';
+import { Context } from '../../lib/interfaces';
+import makeRpcRequest from '../../utils/makeRpcRequest';
+import { FlipConfig } from '../../config/interfaces';
+import { ProtocolData } from '../../utils/utils';
+
+const metricNameOraclePrices: string = 'cf_oracle_price';
+const metricOraclePrices: Gauge = new promClient.Gauge({
+    name: metricNameOraclePrices,
+    help: 'Price of the asset in usd',
+    registers: [],
+    labelNames: ['asset'],
+});
+
+const metricNameOraclePricesDelta: string = 'cf_oracle_price_delta';
+const metricOraclePricesDelta: Gauge = new promClient.Gauge({
+    name: metricNameOraclePricesDelta,
+    help: 'Delta of the price of the asset in % compared to coingecko prices',
+    registers: [],
+    labelNames: ['asset'],
+});
+
+const decimals = {
+    Btc: 8,
+    Eth: 18,
+    Usdc: 6,
+    Usdt: 6,
+    Sol: 9,
+} as const;
+
+type BaseAsset = keyof typeof decimals;
+
+function hexPriceToPrice(
+    hex_price: bigint,
+    decimals_of_quote_asset: number,
+    decimals_of_base_asset: number,
+) {
+    return (
+        (Number(BigInt(hex_price)) / 2 ** 128) *
+        10 ** (decimals_of_base_asset - decimals_of_quote_asset)
+    );
+}
+
+export const gaugeOraclePrices = async (context: Context, data: ProtocolData): Promise<void> => {
+    if (context.config.skipMetrics.includes('cf_oracle_price')) {
+        return;
+    }
+    const { logger, apiLatest, registry, metricFailure } = context;
+    const config = context.config as FlipConfig;
+
+    logger.debug(`Scraping ${metricNameOraclePrices}, ${metricNameOraclePricesDelta}`);
+
+    if (registry.getSingleMetric(metricNameOraclePrices) === undefined)
+        registry.registerMetric(metricOraclePrices);
+    if (registry.getSingleMetric(metricNameOraclePricesDelta) === undefined)
+        registry.registerMetric(metricOraclePricesDelta);
+
+    metricFailure.labels({ metric: metricNameOraclePrices }).set(0);
+    metricFailure.labels({ metric: metricNameOraclePricesDelta }).set(0);
+
+    try {
+        const result = await makeRpcRequest(apiLatest, 'oracle_prices', undefined, data.blockHash);
+        for (const asset of result) {
+            const baseAsset = asset.base_asset;
+            if (!(baseAsset in decimals)) {
+                continue;
+            }
+            const typedBase = baseAsset as BaseAsset;
+            const price = hexPriceToPrice(asset.price, 6, decimals[typedBase]);
+            metricOraclePrices.labels(asset.base_asset).set(price);
+
+            if (global.prices) {
+                const globalPrice = global.prices.get(typedBase);
+                if (globalPrice && globalPrice !== 0) {
+                    const delta = Number(percentageDifference(price, globalPrice).toFixed(4));
+                    metricOraclePricesDelta.labels(asset.base_asset).set(delta);
+                }
+            }
+        }
+    } catch (e) {
+        logger.error(e);
+        metricFailure.labels({ metric: metricNameOraclePrices }).set(1);
+        metricFailure.labels({ metric: metricNameOraclePricesDelta }).set(1);
+    }
+};
+
+function percentageDifference(price: number, globalPrice: number) {
+    return ((price - globalPrice) / globalPrice) * 100;
+}

--- a/src/metrics/chainflip/gaugePriceDelta.ts
+++ b/src/metrics/chainflip/gaugePriceDelta.ts
@@ -232,6 +232,7 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
         formattedData.forEach((element: any) => {
             prices.set(element.chainId.toString().concat(element.address), element.usdPrice);
         });
+        setGlobalPrices(prices);
 
         /// ... -> USDC
         calculateRateToUsdc(BTC, pointOneBtc);
@@ -349,3 +350,30 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
         }
     }
 };
+
+function setGlobalPrices(prices: Map<string, number>) {
+    const BtcPrice = prices.get(BTC.priceId);
+    if (BtcPrice) {
+        global.prices.set('Btc', BtcPrice);
+    }
+
+    const EthPrice = prices.get(ETH.priceId);
+    if (EthPrice) {
+        global.prices.set('Eth', EthPrice);
+    }
+
+    const SolPrice = prices.get(SOL.priceId);
+    if (SolPrice) {
+        global.prices.set('Sol', SolPrice);
+    }
+
+    const UsdcPrice = prices.get(USDCPriceId);
+    if (UsdcPrice) {
+        global.prices.set('Usdc', UsdcPrice);
+    }
+
+    const UsdtPrice = prices.get(USDT.priceId);
+    if (UsdtPrice) {
+        global.prices.set('Usdt', UsdtPrice);
+    }
+}

--- a/src/metrics/chainflip/gaugeValidatorStatus.ts
+++ b/src/metrics/chainflip/gaugeValidatorStatus.ts
@@ -18,13 +18,6 @@ const metricAuthority: Gauge = new promClient.Gauge({
     registers: [],
     labelNames: ['ss58Address', 'alias'],
 });
-const metricNameValidatorBackup: string = 'cf_validator_backup';
-const metricBackup: Gauge = new promClient.Gauge({
-    name: metricNameValidatorBackup,
-    help: 'Tracked validator is backup',
-    registers: [],
-    labelNames: ['ss58Address', 'alias'],
-});
 const metricNameValidatorQualified: string = 'cf_validator_qualified';
 const metricQualified: Gauge = new promClient.Gauge({
     name: metricNameValidatorQualified,
@@ -65,15 +58,13 @@ export const gaugeValidatorStatus = async (context: Context, data: ProtocolData)
     }
 
     logger.debug(
-        `Scraping ${metricNameValidatorOnline}, ${metricNameValidatorAuthority}, ${metricNameValidatorBackup}, ${metricNameValidatorQualified}, ${metricNameReputation}`,
+        `Scraping ${metricNameValidatorOnline}, ${metricNameValidatorAuthority}, ${metricNameValidatorQualified}, ${metricNameReputation}`,
     );
 
     if (registry.getSingleMetric(metricNameValidatorOnline) === undefined)
         registry.registerMetric(metricAuthorityOnline);
     if (registry.getSingleMetric(metricNameValidatorAuthority) === undefined)
         registry.registerMetric(metricAuthority);
-    if (registry.getSingleMetric(metricNameValidatorBackup) === undefined)
-        registry.registerMetric(metricBackup);
     if (registry.getSingleMetric(metricNameValidatorQualified) === undefined)
         registry.registerMetric(metricQualified);
     if (registry.getSingleMetric(metricNameValidatorBidding) === undefined)
@@ -85,7 +76,6 @@ export const gaugeValidatorStatus = async (context: Context, data: ProtocolData)
 
     metricFailure.labels({ metric: metricNameValidatorOnline }).set(0);
     metricFailure.labels({ metric: metricNameValidatorAuthority }).set(0);
-    metricFailure.labels({ metric: metricNameValidatorBackup }).set(0);
     metricFailure.labels({ metric: metricNameValidatorQualified }).set(0);
     metricFailure.labels({ metric: metricNameValidatorBidding }).set(0);
     metricFailure.labels({ metric: metricNameValidatorBalance }).set(0);
@@ -113,7 +103,6 @@ export const gaugeValidatorStatus = async (context: Context, data: ProtocolData)
                 const {
                     balance,
                     is_current_authority,
-                    is_current_backup,
                     is_online,
                     is_bidding,
                     is_qualified,
@@ -126,9 +115,6 @@ export const gaugeValidatorStatus = async (context: Context, data: ProtocolData)
                 metricAuthority
                     .labels(chunk[i], vanityNamesChunked[j][i])
                     .set(is_current_authority ? 1 : 0);
-                metricBackup
-                    .labels(chunk[i], vanityNamesChunked[j][i])
-                    .set(is_current_backup ? 1 : 0);
                 metricQualified
                     .labels(chunk[i], vanityNamesChunked[j][i])
                     .set(is_qualified ? 1 : 0);
@@ -143,7 +129,6 @@ export const gaugeValidatorStatus = async (context: Context, data: ProtocolData)
         logger.error(e);
         metricFailure.labels({ metric: metricNameValidatorOnline }).set(1);
         metricFailure.labels({ metric: metricNameValidatorAuthority }).set(1);
-        metricFailure.labels({ metric: metricNameValidatorBackup }).set(1);
         metricFailure.labels({ metric: metricNameValidatorQualified }).set(1);
         metricFailure.labels({ metric: metricNameValidatorBidding }).set(1);
         metricFailure.labels({ metric: metricNameValidatorBalance }).set(1);

--- a/src/metrics/chainflip/index.ts
+++ b/src/metrics/chainflip/index.ts
@@ -23,3 +23,4 @@ export * from './gaugePriceDelta';
 export * from './gaugeDepositChannels';
 export * from './gaugeSolanaDurableNonces';
 export * from './gaugeBitcoinElections';
+export * from './gaugeOraclePrices';

--- a/src/metrics/sol/gaugeTransactionsOutcome.ts
+++ b/src/metrics/sol/gaugeTransactionsOutcome.ts
@@ -25,7 +25,10 @@ export const gaugeTxOutcome = async (context: Context) => {
     try {
         if (global.solanaRotationTx) {
             lastRotationTx = global.solanaRotationTx;
-            const txResult = await connection.getTransaction(global.solanaRotationTx);
+            const txResult = await connection.getTransaction(global.solanaRotationTx, {
+                commitment: 'finalized',
+                maxSupportedTransactionVersion: 0,
+            });
             if (txResult !== null) {
                 // tx reverted:
                 if (txResult.meta.err !== null) {

--- a/src/utils/customRpcSpecification.ts
+++ b/src/utils/customRpcSpecification.ts
@@ -143,5 +143,10 @@ export const customRpcs = {
             type: 'RpcMonitoringAccountInfo',
             description: '',
         },
+        oracle_prices: {
+            params: [],
+            type: 'RpcOraclePrices',
+            description: '',
+        },
     },
 };

--- a/src/utils/makeRpcRequest.ts
+++ b/src/utils/makeRpcRequest.ts
@@ -103,7 +103,7 @@ export const customRpcTypes = {
             rotation_phase: string,
         }),
         pending_redemptions: z.object({
-            total_balance: U128, // maybe u128
+            total_balance: U128,
             count: U32,
         }),
         pending_broadcasts: z.object({
@@ -176,10 +176,22 @@ export const customRpcTypes = {
             reputation_points: I32,
             keyholder_epochs: z.array(U32),
             is_current_authority: boolean,
-            is_current_backup: boolean,
             is_qualified: boolean,
             is_online: boolean,
             is_bidding: boolean,
+            bound_redeem_address: z.optional(string),
+            apy_bp: z.optional(U32),
+            estimated_redeemable_balance: U128,
+            operator: z.optional(string),
+        }),
+    ),
+    oracle_prices: z.array(
+        z.object({
+            price: U128,
+            updated_at_oracle_timestamp: U128,
+            updated_at_statechain_block: U32,
+            base_asset: string,
+            quote_asset: string,
         }),
     ),
 } as const;
@@ -200,6 +212,7 @@ type RpcParamsMap = {
     monitoring_data: [at?: string];
     monitoring_accounts_info: [accounts: string[], at?: string];
     safe_mode_statuses: [];
+    oracle_prices: [asset_pair?: string, at?: string];
 };
 
 type RpcCall = keyof RpcParamsMap & keyof typeof customRpcTypes & keyof typeof customRpcs.cf;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,6 +15,7 @@ declare global {
     var solanaRotationTx: string;
     var solanaCurrentOnChainKey: string;
     var solanaBlockHeight: number;
+    var prices: Map<string, number>;
 
     interface CustomApiPromise extends ApiPromise {
         rpc: ApiPromise['rpc'] & {

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -25,6 +25,7 @@ import {
     gaugeSolanaNonces,
     gaugeBlockWeight,
     gaugeBitcoinElections,
+    gaugeOraclePrices,
 } from '../metrics/chainflip';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { customRpcs } from '../utils/customRpcSpecification';
@@ -64,6 +65,7 @@ async function startWatcher(context: Context) {
     if (registry.getSingleMetric(metricFailureName) === undefined)
         registry.registerMetric(metricFailure);
     global.currentBlock = 0;
+    global.prices = new Map();
     try {
         const provider = new WsProvider(env.CF_WS_ENDPOINT, 5000);
         provider.on('disconnected', async (err) => {
@@ -113,6 +115,7 @@ async function startWatcher(context: Context) {
             gaugeValidatorStatus(context, data);
             gaugeBuildVersion(context, data);
             gaugePriceDelta(context, data);
+            gaugeOraclePrices(context, data);
             gaugeBitcoinElections(context, data);
             metric.set(0);
         });


### PR DESCRIPTION
Added 2 new metrics:
- `cf_oracle_price` -> expose the oracle price
- `cf_oracle_price_delta` -> expose the %difference of our oracle price compared to the index price (coingecko)


- Removed backup validators
- Fixed a bug while querying solana rotation tx