### PR TITLE
feat: add other oracle metrics

### DIFF
--- a/src/metrics/chainflip/gaugeOraclePrices.ts
+++ b/src/metrics/chainflip/gaugeOraclePrices.ts
@@ -12,6 +12,22 @@ const metricOraclePrices: Gauge = new promClient.Gauge({
     labelNames: ['asset'],
 });
 
+const metricNameOraclePricesTimestamp: string = 'cf_oracle_price_timestamp';
+const metricOraclePricesTimestamp: Gauge = new promClient.Gauge({
+    name: metricNameOraclePricesTimestamp,
+    help: 'Unix Timestamp of the last update of the asset price',
+    registers: [],
+    labelNames: ['asset'],
+});
+
+const metricNameOraclePricesBlock: string = 'cf_oracle_price_block';
+const metricOraclePricesBlock: Gauge = new promClient.Gauge({
+    name: metricNameOraclePricesBlock,
+    help: 'Statechain block of the last update of the asset price',
+    registers: [],
+    labelNames: ['asset'],
+});
+
 const metricNameOraclePricesDelta: string = 'cf_oracle_price_delta';
 const metricOraclePricesDelta: Gauge = new promClient.Gauge({
     name: metricNameOraclePricesDelta,
@@ -54,6 +70,10 @@ export const gaugeOraclePrices = async (context: Context, data: ProtocolData): P
         registry.registerMetric(metricOraclePrices);
     if (registry.getSingleMetric(metricNameOraclePricesDelta) === undefined)
         registry.registerMetric(metricOraclePricesDelta);
+    if (registry.getSingleMetric(metricNameOraclePricesTimestamp) === undefined)
+        registry.registerMetric(metricOraclePricesTimestamp);
+    if (registry.getSingleMetric(metricNameOraclePricesBlock) === undefined)
+        registry.registerMetric(metricOraclePricesBlock);
 
     metricFailure.labels({ metric: metricNameOraclePrices }).set(0);
     metricFailure.labels({ metric: metricNameOraclePricesDelta }).set(0);
@@ -68,6 +88,12 @@ export const gaugeOraclePrices = async (context: Context, data: ProtocolData): P
             const typedBase = baseAsset as BaseAsset;
             const price = hexPriceToPrice(asset.price, 6, decimals[typedBase]);
             metricOraclePrices.labels(asset.base_asset).set(price);
+
+            metricOraclePricesTimestamp
+                .labels(asset.base_asset)
+                .set(asset.updated_at_oracle_timestamp);
+
+            metricOraclePricesBlock.labels(asset.base_asset).set(asset.updated_at_statechain_block);
 
             if (global.prices) {
                 const globalPrice = global.prices.get(typedBase);

--- a/src/metrics/chainflip/gaugePriceDelta.ts
+++ b/src/metrics/chainflip/gaugePriceDelta.ts
@@ -191,7 +191,7 @@ const fiftySol = '50000000000';
 
 let swapSDK: SwapSDK | undefined;
 export const gaugePriceDelta = async (context: Context, data: ProtocolData): Promise<void> => {
-    if (context.config.skipMetrics.includes('cf_price_delta')) {
+    if (context.config.skipMetrics.includes('cf_prices')) {
         return;
     }
     const { logger, apiLatest, registry, metricFailure } = context;
@@ -225,6 +225,10 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
             prices.set(element.chainId.toString().concat(element.address), element.usdPrice);
         });
         setGlobalPrices(prices);
+
+        if (context.config.skipMetrics.includes('cf_price_delta')) {
+            return;
+        }
 
         /// ... -> USDC
         calculateRateToUsdc(BTC, pointOneBtc);

--- a/src/utils/makeRpcRequest.ts
+++ b/src/utils/makeRpcRequest.ts
@@ -181,7 +181,7 @@ export const customRpcTypes = {
     oracle_prices: z.array(
         z.object({
             price: U128,
-            updated_at_oracle_timestamp: U128,
+            updated_at_oracle_timestamp: U32,
             updated_at_statechain_block: U32,
             base_asset: string,
             quote_asset: string,


### PR DESCRIPTION
added:
- cf_oracle_price_timestamp
- cf_oracle_price_block

Added second conditions to `cf_price_delta` such that we can still get real prices in sisyphos/perseverance without calculating the deltas