### PR TITLE
feat: add delegation metrics

### DIFF
--- a/src/metrics/chainflip/gaugeDelegation.ts
+++ b/src/metrics/chainflip/gaugeDelegation.ts
@@ -1,0 +1,107 @@
+import promClient, { Gauge } from 'prom-client';
+import { Context } from '../../lib/interfaces';
+import makeRpcRequest from '../../utils/makeRpcRequest';
+import { FlipConfig } from '../../config/interfaces';
+import { ProtocolData } from '../../utils/utils';
+
+const metricNameBondDifference: string = 'cf_bond_difference';
+const metricBondDifference: Gauge = new promClient.Gauge({
+    name: metricNameBondDifference,
+    help: 'The difference of the next epoch bond compared to the current one',
+    registers: [],
+    labelNames: [],
+});
+
+const metricNameCurrentBond: string = 'cf_current_bond';
+const metricCurrentBond: Gauge = new promClient.Gauge({
+    name: metricNameCurrentBond,
+    help: 'The current epoch bond',
+    registers: [],
+    labelNames: [],
+});
+
+const metricNameNextBond: string = 'cf_next_bond';
+const metricNextBond: Gauge = new promClient.Gauge({
+    name: metricNameNextBond,
+    help: 'The next epoch bond',
+    registers: [],
+    labelNames: [],
+});
+
+const metricNameNewValidators: string = 'cf_new_validators';
+const metricNewValidators: Gauge = new promClient.Gauge({
+    name: metricNameNewValidators,
+    help: 'The number of new validator joining the active set the next epoch',
+    registers: [],
+    labelNames: [],
+});
+
+const metricNameOperatorDelegatedBalance: string = 'cf_operator_delegated_balance';
+const metricOperatorDelegatedBalance: Gauge = new promClient.Gauge({
+    name: metricNameOperatorDelegatedBalance,
+    help: 'The amount of FLIP delegated to an operator',
+    registers: [],
+    labelNames: ['operator'],
+});
+
+export const gaugeDelegation = async (context: Context, data: ProtocolData): Promise<void> => {
+    if (context.config.skipMetrics.includes('cf_simulate_auction')) {
+        return;
+    }
+    const { logger, apiLatest, registry, metricFailure } = context;
+    const config = context.config as FlipConfig;
+
+    logger.debug(
+        `Scraping ${metricNameBondDifference}, ${metricNameCurrentBond}, ${metricNameNextBond}, ${metricNameNewValidators}, ${metricNameOperatorDelegatedBalance}`,
+    );
+
+    if (registry.getSingleMetric(metricNameBondDifference) === undefined)
+        registry.registerMetric(metricBondDifference);
+    if (registry.getSingleMetric(metricNameNewValidators) === undefined)
+        registry.registerMetric(metricNewValidators);
+    if (registry.getSingleMetric(metricNameNextBond) === undefined)
+        registry.registerMetric(metricNextBond);
+    if (registry.getSingleMetric(metricNameOperatorDelegatedBalance) === undefined)
+        registry.registerMetric(metricOperatorDelegatedBalance);
+    if (registry.getSingleMetric(metricNameCurrentBond) === undefined)
+        registry.registerMetric(metricCurrentBond);
+
+    metricFailure.labels({ metric: metricNameBondDifference }).set(0);
+    metricFailure.labels({ metric: metricNameNewValidators }).set(0);
+    metricFailure.labels({ metric: metricNameNextBond }).set(0);
+    metricFailure.labels({ metric: metricNameOperatorDelegatedBalance }).set(0);
+    metricFailure.labels({ metric: metricNameCurrentBond }).set(0);
+
+    try {
+        const result = await makeRpcRequest(
+            apiLatest,
+            'monitoring_simulate_auction',
+            context.blockHash,
+        );
+
+        metricNewValidators.set(result.new_validators.length);
+
+        const bondDifference = Number(
+            (BigInt(result.auction_outcome.bond) - BigInt(result.current_mab)) / BigInt(1e18),
+        );
+        metricBondDifference.set(bondDifference);
+
+        metricNextBond.set(Number(BigInt(result.auction_outcome.bond) / BigInt(1e18)));
+        metricCurrentBond.set(Number(BigInt(result.current_mab) / BigInt(1e18)));
+
+        for (const [, entry] of Object.entries(result.operators_info)) {
+            let total_delegated = 0;
+            for (const [, val] of Object.entries(entry.delegators)) {
+                total_delegated += Number(BigInt(val)) / 1e18;
+            }
+            metricOperatorDelegatedBalance.labels(entry.operator).set(total_delegated);
+        }
+    } catch (e) {
+        logger.error(e);
+        metricFailure.labels({ metric: metricNameBondDifference }).set(1);
+        metricFailure.labels({ metric: metricNameNewValidators }).set(1);
+        metricFailure.labels({ metric: metricNameNextBond }).set(1);
+        metricFailure.labels({ metric: metricNameOperatorDelegatedBalance }).set(1);
+        metricFailure.labels({ metric: metricNameCurrentBond }).set(1);
+    }
+};

--- a/src/metrics/chainflip/index.ts
+++ b/src/metrics/chainflip/index.ts
@@ -24,3 +24,4 @@ export * from './gaugeDepositChannels';
 export * from './gaugeSolanaDurableNonces';
 export * from './gaugeBitcoinElections';
 export * from './gaugeOraclePrices';
+export * from './gaugeDelegation';

--- a/src/utils/customRpcSpecification.ts
+++ b/src/utils/customRpcSpecification.ts
@@ -148,5 +148,10 @@ export const customRpcs = {
             type: 'RpcOraclePrices',
             description: '',
         },
+        monitoring_simulate_auction: {
+            params: [],
+            type: 'RpcMonitoringSimulateAuction',
+            description: '',
+        },
     },
 };

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -26,6 +26,7 @@ import {
     gaugeBlockWeight,
     gaugeBitcoinElections,
     gaugeOraclePrices,
+    gaugeDelegation,
 } from '../metrics/chainflip';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { customRpcs } from '../utils/customRpcSpecification';
@@ -106,6 +107,7 @@ async function startWatcher(context: Context) {
             gaugeKeyActivationBroadcast(context, data);
             gaugeSolanaNonces(context, data);
 
+            gaugeDelegation(context, data);
             gaugeSafeMode(context, data);
             gaugeOpenElections(context, data);
             gaugeBlockWeight(context, data);


### PR DESCRIPTION
Added new metrics to track delegation:
- current bond
- next bond
- difference between the two above
- number of new validators joining the set
- amount of flip delegated to an operator