### PR TITLE
feat: add backpressure to chainflip watcher

### DIFF
--- a/config/berghain.json
+++ b/config/berghain.json
@@ -205,7 +205,24 @@
     "network": "mainnet",
     "defaultMetrics": [],
     "contracts": [],
-    "wallets": [],
+    "wallets": [
+      {
+        "alias": "bashful",
+        "address": "419c1bc912afa4eb8a516ed50378e6163360264e84"
+      },
+      {
+        "alias": "doc",
+        "address": "410cb6f56ccefd56fbefca4146ca1dd9949100eb62"
+      },
+      {
+        "alias": "dopey",
+        "address": "41d0b108995911377d8d32b652c5dd1c233a6afc87"
+      },
+      {
+        "alias": "vault",
+        "address": "4132e07e5dfcb75c2977adddc593eb8d6b6e71f96e"
+      }
+    ],
     "tokens": [],
     "skipMetrics": []
   }

--- a/src/metrics/chainflip/countEvents.ts
+++ b/src/metrics/chainflip/countEvents.ts
@@ -75,6 +75,74 @@ function cleanupStaleCcmBroadcasts(currentBlock: number, logger: any) {
     }
 }
 
+export const resetEventCountMetrics = (config: FlipConfig): void => {
+    metric.reset();
+    metricExtrinsicFailed.reset();
+    metricSlash.reset();
+    metricCcmBroadcastAborted.reset();
+    metricBroadcastAborted.reset();
+    metricReorgDetected.reset();
+    activeReorgChains.clear();
+
+    metric.labels('governance:Approved').set(0);
+    metric.labels('governance:Executed').set(0);
+    metric.labels('governance:Proposed').set(0);
+    metric.labels('ethereumBroadcaster:BroadcastAborted').set(0);
+    metric.labels('arbitrumBroadcaster:BroadcastAborted').set(0);
+    metric.labels('bitcoinBroadcaster:BroadcastAborted').set(0);
+    metric.labels('solanaBroadcaster:BroadcastAborted').set(0);
+    metric.labels('bitcoinBroadcaster:BroadcastTimeout').set(0);
+    metric.labels('ethereumBroadcaster:BroadcastTimeout').set(0);
+    metric.labels('arbitrumBroadcaster:BroadcastTimeout').set(0);
+    metric.labels('solanaBroadcaster:BroadcastTimeout').set(0);
+    metric.labels('evmThresholdSigner:RetryRequested').set(0);
+    metric.labels('bitcoinThresholdSigner:RetryRequested').set(0);
+    metric.labels('solanaThresholdSigner:RetryRequested').set(0);
+    metric.labels('evmThresholdSigner:KeygenFailure').set(0);
+    metric.labels('bitcoinThresholdSigner:KeygenFailure').set(0);
+    metric.labels('solanaThresholdSigner:KeygenFailure').set(0);
+    metric.labels('solanaIngressEgress:ChannelOpeningFeePaid').set(0);
+    metric.labels('bitcoinIngressEgress:ChannelOpeningFeePaid').set(0);
+    metric.labels('ethereumIngressEgress:ChannelOpeningFeePaid').set(0);
+    metric.labels('arbitrumIngressEgress:ChannelOpeningFeePaid').set(0);
+    metric.labels('flip:SlashingPerformed').set(0);
+    metric.labels('ethereumChainTracking:ChainStateUpdated').set(0);
+    metric.labels('bitcoinChainTracking:ChainStateUpdated').set(0);
+    metric.labels('arbitrumChainTracking:ChainStateUpdated').set(0);
+    metric.labels('bitcoinIngressEgress:BoostedDepositLost').set(0);
+    metric.labels('arbitrumIngressEgress:TransferFallbackRequested').set(0);
+    metric.labels('ethereumIngressEgress:TransferFallbackRequested').set(0);
+    metric.labels('solanaIngressEgress:TransferFallbackRequested').set(0);
+    metric.labels('assethubIngressEgress:TransferFallbackRequested').set(0);
+    metric.labels('bitcoinIngressEgress:TransferFallbackRequested').set(0);
+    metric.labels('tronBroadcaster:BroadcastAborted').set(0);
+    metric.labels('tronBroadcaster:BroadcastTimeout').set(0);
+    metric.labels('tronIngressEgress:ChannelOpeningFeePaid').set(0);
+    metric.labels('tronChainTracking:ChainStateUpdated').set(0);
+    metric.labels('tronIngressEgress:TransferFallbackRequested').set(0);
+
+    metricReorgDetected.labels('bitcoin').set(0);
+    metricReorgDetected.labels('ethereum').set(0);
+    metricReorgDetected.labels('arbitrum').set(0);
+    metricReorgDetected.labels('tron').set(0);
+
+    for (const { ss58Address, alias } of config.accounts) {
+        const hex = `0x${Buffer.from(decodeAddress(ss58Address)).toString('hex')}`;
+        metricSlash.labels(ss58Address, hex, alias).set(0);
+    }
+
+    for (const broadcaster of [
+        'arbitrumBroadcaster',
+        'bitcoinBroadcaster',
+        'ethereumBroadcaster',
+        'solanaBroadcaster',
+        'tronBroadcaster',
+    ]) {
+        metricCcmBroadcastAborted.labels(broadcaster).set(0);
+        metricBroadcastAborted.labels(broadcaster).set(0);
+    }
+};
+
 export const countEvents = async (context: Context, data: ProtocolData): Promise<void> => {
     if (context.config.skipMetrics.includes('cf_events_count_total')) {
         return;
@@ -87,77 +155,17 @@ export const countEvents = async (context: Context, data: ProtocolData): Promise
     logger.debug('scraping', { metric: metricName, blockNumber: data.blockNumber });
 
     try {
-        if (registry.getSingleMetric(metricName) === undefined) {
-            registry.registerMetric(metric);
-            metric.labels('governance:Approved').set(0);
-            metric.labels('governance:Executed').set(0);
-            metric.labels('governance:Proposed').set(0);
-            metric.labels('ethereumBroadcaster:BroadcastAborted').set(0);
-            metric.labels('arbitrumBroadcaster:BroadcastAborted').set(0);
-            metric.labels('bitcoinBroadcaster:BroadcastAborted').set(0);
-            metric.labels('solanaBroadcaster:BroadcastAborted').set(0);
-            metric.labels('bitcoinBroadcaster:BroadcastTimeout').set(0);
-            metric.labels('ethereumBroadcaster:BroadcastTimeout').set(0);
-            metric.labels('arbitrumBroadcaster:BroadcastTimeout').set(0);
-            metric.labels('solanaBroadcaster:BroadcastTimeout').set(0);
-            metric.labels('evmThresholdSigner:RetryRequested').set(0);
-            metric.labels('bitcoinThresholdSigner:RetryRequested').set(0);
-            metric.labels('solanaThresholdSigner:RetryRequested').set(0);
-            metric.labels('evmThresholdSigner:KeygenFailure').set(0);
-            metric.labels('bitcoinThresholdSigner:KeygenFailure').set(0);
-            metric.labels('solanaThresholdSigner:KeygenFailure').set(0);
-            metric.labels('solanaIngressEgress:ChannelOpeningFeePaid').set(0);
-            metric.labels('bitcoinIngressEgress:ChannelOpeningFeePaid').set(0);
-            metric.labels('ethereumIngressEgress:ChannelOpeningFeePaid').set(0);
-            metric.labels('arbitrumIngressEgress:ChannelOpeningFeePaid').set(0);
-            metric.labels('flip:SlashingPerformed').set(0);
-            metric.labels('ethereumChainTracking:ChainStateUpdated').set(0);
-            metric.labels('bitcoinChainTracking:ChainStateUpdated').set(0);
-            metric.labels('arbitrumChainTracking:ChainStateUpdated').set(0);
-            metric.labels('bitcoinIngressEgress:BoostedDepositLost').set(0);
-            metric.labels('arbitrumIngressEgress:TransferFallbackRequested').set(0);
-            metric.labels('ethereumIngressEgress:TransferFallbackRequested').set(0);
-            metric.labels('solanaIngressEgress:TransferFallbackRequested').set(0);
-            metric.labels('assethubIngressEgress:TransferFallbackRequested').set(0);
-            metric.labels('bitcoinIngressEgress:TransferFallbackRequested').set(0);
-            metric.labels('tronBroadcaster:BroadcastAborted').set(0);
-            metric.labels('tronBroadcaster:BroadcastTimeout').set(0);
-            metric.labels('tronIngressEgress:ChannelOpeningFeePaid').set(0);
-            metric.labels('tronChainTracking:ChainStateUpdated').set(0);
-            metric.labels('tronIngressEgress:TransferFallbackRequested').set(0);
-            metricReorgDetected.labels('bitcoin').set(0);
-            metricReorgDetected.labels('ethereum').set(0);
-            metricReorgDetected.labels('arbitrum').set(0);
-            metricReorgDetected.labels('tron').set(0);
-        }
+        if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
         if (registry.getSingleMetric(metricExtrinsicFailedName) === undefined)
             registry.registerMetric(metricExtrinsicFailed);
-        if (registry.getSingleMetric(metricNameSlashing) === undefined) {
+        if (registry.getSingleMetric(metricNameSlashing) === undefined)
             registry.registerMetric(metricSlash);
-            for (const { ss58Address, alias } of accounts) {
-                const hex = `0x${Buffer.from(decodeAddress(ss58Address)).toString('hex')}`;
-                metricSlash.labels(ss58Address, hex, alias).set(0);
-            }
-        }
-        if (registry.getSingleMetric(metricNameCcmBroadcastAborted) === undefined) {
+        if (registry.getSingleMetric(metricNameCcmBroadcastAborted) === undefined)
             registry.registerMetric(metricCcmBroadcastAborted);
-            metricCcmBroadcastAborted.labels('arbitrumBroadcaster').set(0);
-            metricCcmBroadcastAborted.labels('bitcoinBroadcaster').set(0);
-            metricCcmBroadcastAborted.labels('ethereumBroadcaster').set(0);
-            metricCcmBroadcastAborted.labels('solanaBroadcaster').set(0);
-            metricCcmBroadcastAborted.labels('tronBroadcaster').set(0);
-        }
-        if (registry.getSingleMetric(metricNameBroadcastAborted) === undefined) {
+        if (registry.getSingleMetric(metricNameBroadcastAborted) === undefined)
             registry.registerMetric(metricBroadcastAborted);
-            metricBroadcastAborted.labels('arbitrumBroadcaster').set(0);
-            metricBroadcastAborted.labels('bitcoinBroadcaster').set(0);
-            metricBroadcastAborted.labels('ethereumBroadcaster').set(0);
-            metricBroadcastAborted.labels('solanaBroadcaster').set(0);
-            metricBroadcastAborted.labels('tronBroadcaster').set(0);
-        }
-        if (registry.getSingleMetric(metricNameReorgDetected) === undefined) {
+        if (registry.getSingleMetric(metricNameReorgDetected) === undefined)
             registry.registerMetric(metricReorgDetected);
-        }
         cleanupStaleCcmBroadcasts(data.blockNumber, logger);
         logStructureSize(
             logger,

--- a/src/metrics/chainflip/gatherGlobalValues.ts
+++ b/src/metrics/chainflip/gatherGlobalValues.ts
@@ -6,4 +6,6 @@ export const gatherGlobalValues = (data: ProtocolData): void => {
     global.solAggKeyAddress = data.data.sol_aggkey;
     global.dotAggKeyAddress = data.data.dot_aggkey;
     global.solanaCurrentOnChainKey = data.data.sol_onchain_key;
+    global.currentAuthorities = data.data.authorities.authorities;
+    global.rotationInProgress = data.data.epoch.rotation_phase !== 'Idle';
 };

--- a/src/metrics/chainflip/gaugeAuthorities.ts
+++ b/src/metrics/chainflip/gaugeAuthorities.ts
@@ -51,7 +51,6 @@ export const gaugeAuthorities = async (context: Context, data: ProtocolData): Pr
             registry.registerMetric(metricOnlineBackups);
 
         metricAuthorities.set(data.data.authorities.authorities);
-        global.currentAuthorities = data.data.authorities.authorities;
         metricOnlineAuthorities.set(data.data.authorities.online_authorities);
 
         metricBackups.set(data.data.authorities.backups);

--- a/src/metrics/chainflip/gaugeEpoch.ts
+++ b/src/metrics/chainflip/gaugeEpoch.ts
@@ -61,15 +61,7 @@ export const gaugeEpoch = async (context: Context, data: ProtocolData): Promise<
             data.blockNumber - data.data.epoch.current_epoch_started_at;
         metricEpochDuration.set(currentEpochDurationBlocks);
 
-        let metricValue: number;
-        if (data.data.epoch.rotation_phase === 'Idle') {
-            global.rotationInProgress = false;
-            metricValue = 0;
-        } else {
-            global.rotationInProgress = true;
-            metricValue = 1;
-        }
-        metricRotating.set(metricValue);
+        metricRotating.set(data.data.epoch.rotation_phase === 'Idle' ? 0 : 1);
 
         metricFailure.labels({ metric: metricNameBlocksPerEpoch }).set(0);
         metricFailure.labels({ metric: metricNameMAB }).set(0);

--- a/src/metrics/chainflip/gaugePriceDelta.ts
+++ b/src/metrics/chainflip/gaugePriceDelta.ts
@@ -185,6 +185,8 @@ const HUBUSDT: asset = {
     chainAssetPriceId: DOTPriceId,
 };
 
+const QUOTE_TIMEOUT_MS = 10_000;
+
 const pointOneBtc = '10000000';
 const pointFiveBtc = '50000000';
 const oneBtc = '100000000';
@@ -248,43 +250,48 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
             return;
         }
 
-        /// ... -> USDC
-        calculateRateToUsdc(BTC, pointOneBtc);
-        calculateRateToUsdc(BTC, pointFiveBtc);
-        calculateRateToUsdc(BTC, oneBtc);
-        calculateRateToUsdc(ETH, fiveEth);
-        calculateRateToUsdc(ETH, twentyEth);
-        calculateRateToUsdc(FLIP, fiveKFlip);
-        calculateRateToUsdc(FLIP, tenKFlip);
-        calculateRateToUsdc(ARBETH, fiveEth);
-        calculateRateToUsdc(ARBETH, twentyEth);
-        calculateRateToUsdc(ARBUSDC, tenKUsdc);
-        calculateRateToUsdc(ARBUSDC, fiftyKUsdc);
-        calculateRateToUsdc(USDT, tenKUsdc);
-        calculateRateToUsdc(USDT, fiftyKUsdc);
-        calculateRateToUsdc(SOL, fiftySol);
-        calculateRateToUsdc(HUBDOT, oneKDot);
-        calculateRateToUsdc(HUBUSDC, tenKUsdc);
-        calculateRateToUsdc(HUBUSDT, tenKUsdc);
+        // Awaited so the per-block pipeline can apply backpressure: no quote
+        // request may outlive this gauge (each one is also bounded by
+        // QUOTE_TIMEOUT_MS).
+        await Promise.allSettled([
+            /// ... -> USDC
+            calculateRateToUsdc(BTC, pointOneBtc),
+            calculateRateToUsdc(BTC, pointFiveBtc),
+            calculateRateToUsdc(BTC, oneBtc),
+            calculateRateToUsdc(ETH, fiveEth),
+            calculateRateToUsdc(ETH, twentyEth),
+            calculateRateToUsdc(FLIP, fiveKFlip),
+            calculateRateToUsdc(FLIP, tenKFlip),
+            calculateRateToUsdc(ARBETH, fiveEth),
+            calculateRateToUsdc(ARBETH, twentyEth),
+            calculateRateToUsdc(ARBUSDC, tenKUsdc),
+            calculateRateToUsdc(ARBUSDC, fiftyKUsdc),
+            calculateRateToUsdc(USDT, tenKUsdc),
+            calculateRateToUsdc(USDT, fiftyKUsdc),
+            calculateRateToUsdc(SOL, fiftySol),
+            calculateRateToUsdc(HUBDOT, oneKDot),
+            calculateRateToUsdc(HUBUSDC, tenKUsdc),
+            calculateRateToUsdc(HUBUSDT, tenKUsdc),
 
-        /// USDC -> ...
-        calculateRateFromUsdc(BTC, tenKUsdc);
-        calculateRateFromUsdc(ETH, tenKUsdc);
-        calculateRateFromUsdc(FLIP, tenKUsdc);
-        calculateRateFromUsdc(BTC, fiftyKUsdc);
-        calculateRateFromUsdc(ETH, fiftyKUsdc);
-        // calculateRateFromUsdc(FLIP, fiftyKUsdc);
-        calculateRateFromUsdc(ARBETH, tenKUsdc);
-        calculateRateFromUsdc(ARBETH, fiftyKUsdc);
-        calculateRateFromUsdc(ARBUSDC, tenKUsdc);
-        calculateRateFromUsdc(ARBUSDC, fiftyKUsdc);
-        calculateRateFromUsdc(USDT, tenKUsdc);
-        calculateRateFromUsdc(USDT, fiftyKUsdc);
-        calculateRateFromUsdc(SOL, tenKUsdc);
-        calculateRateFromUsdc(SOLUSDC, tenKUsdc);
-        calculateRateFromUsdc(HUBDOT, tenKUsdc);
-        calculateRateFromUsdc(HUBUSDC, tenKUsdc);
-        calculateRateFromUsdc(HUBUSDT, tenKUsdc);
+            /// USDC -> ...
+            calculateRateFromUsdc(BTC, tenKUsdc),
+            calculateRateFromUsdc(ETH, tenKUsdc),
+            calculateRateFromUsdc(FLIP, tenKUsdc),
+            calculateRateFromUsdc(BTC, fiftyKUsdc),
+            calculateRateFromUsdc(ETH, fiftyKUsdc),
+            // calculateRateFromUsdc(FLIP, fiftyKUsdc),
+            calculateRateFromUsdc(ARBETH, tenKUsdc),
+            calculateRateFromUsdc(ARBETH, fiftyKUsdc),
+            calculateRateFromUsdc(ARBUSDC, tenKUsdc),
+            calculateRateFromUsdc(ARBUSDC, fiftyKUsdc),
+            calculateRateFromUsdc(USDT, tenKUsdc),
+            calculateRateFromUsdc(USDT, fiftyKUsdc),
+            calculateRateFromUsdc(SOL, tenKUsdc),
+            calculateRateFromUsdc(SOLUSDC, tenKUsdc),
+            calculateRateFromUsdc(HUBDOT, tenKUsdc),
+            calculateRateFromUsdc(HUBUSDC, tenKUsdc),
+            calculateRateFromUsdc(HUBUSDT, tenKUsdc),
+        ]);
     } catch (e) {
         logger.error(e);
         metricFailure.labels('cf_price_delta').set(1);
@@ -302,7 +309,9 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
 
         try {
             // @ts-expect-error "sdk is initialized"
-            const response = await swapSDK.getQuoteV2(quoteRequest);
+            const response = await swapSDK.getQuoteV2(quoteRequest, {
+                signal: AbortSignal.timeout(QUOTE_TIMEOUT_MS),
+            });
             let egressAmount = 0;
             for (const quote of response.quotes) {
                 egressAmount = Math.max(egressAmount, Number(quote.egressAmount) / 1e6);
@@ -336,7 +345,9 @@ export const gaugePriceDelta = async (context: Context, data: ProtocolData): Pro
         };
         try {
             // @ts-expect-error "sdk is initialized"
-            const response = await swapSDK.getQuoteV2(quoteRequest);
+            const response = await swapSDK.getQuoteV2(quoteRequest, {
+                signal: AbortSignal.timeout(QUOTE_TIMEOUT_MS),
+            });
             let egressAmount = 0;
             for (const quote of response.quotes) {
                 egressAmount = Math.max(

--- a/src/utils/blockQueue.ts
+++ b/src/utils/blockQueue.ts
@@ -1,0 +1,73 @@
+export type BlockQueueOptions = {
+    // Max backlog (next..latest). When exceeded, the oldest blocks are dropped.
+    capacity: number;
+    onDrop?: (count: number, fromBlock: number, toBlock: number) => void;
+};
+
+// Bounded, in-order queue of finalized block numbers. Since finalized heads are
+// contiguous monotonic integers, the whole backlog is represented by two cursors:
+// gap-fill (heads skipped by the subscription), duplicate/out-of-order deliveries
+// and the capacity clamp all fall out of the cursor arithmetic, and the queue's
+// memory footprint is constant regardless of how far behind the worker is.
+export class BlockQueue {
+    private next: number | undefined; // next block number take() will return
+    private latest: number | undefined; // highest finalized head seen
+    private waiter: (() => void) | undefined;
+    private stopped = false;
+
+    constructor(private readonly opts: BlockQueueOptions) {}
+
+    // Called from the subscription callback. Never backfills before the first
+    // head seen by this watcher instance.
+    pushHead(head: number): void {
+        if (this.stopped) return;
+        if (this.latest !== undefined && head <= this.latest) return;
+        this.latest = head;
+        if (this.next === undefined) this.next = head;
+        const depth = this.latest - this.next + 1;
+        if (depth > this.opts.capacity) {
+            const newNext = this.latest - this.opts.capacity + 1;
+            this.opts.onDrop?.(newNext - this.next, this.next, newNext - 1);
+            this.next = newNext;
+        }
+        this.wake();
+    }
+
+    // Next block number in strict order, or undefined when caught up / stopped.
+    take(): number | undefined {
+        if (this.stopped || this.next === undefined || this.latest === undefined) return undefined;
+        if (this.next > this.latest) return undefined;
+        return this.next++;
+    }
+
+    get depth(): number {
+        if (this.next === undefined || this.latest === undefined) return 0;
+        return Math.max(0, this.latest - this.next + 1);
+    }
+
+    get latestHead(): number | undefined {
+        return this.latest;
+    }
+
+    // Resolves when a block may be available or stop() is called.
+    async waitForBlock(): Promise<void> {
+        if (this.stopped || this.depth > 0) return;
+        await new Promise<void>((resolve) => {
+            this.waiter = resolve;
+        });
+    }
+
+    get isStopped(): boolean {
+        return this.stopped;
+    }
+
+    stop(): void {
+        this.stopped = true;
+        this.wake();
+    }
+
+    private wake(): void {
+        this.waiter?.();
+        this.waiter = undefined;
+    }
+}

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -1,7 +1,9 @@
 import { Context } from '../lib/interfaces';
+import { FlipConfig } from '../config/interfaces';
 import promClient from 'prom-client';
 import {
     countEvents,
+    resetEventCountMetrics,
     gatherGlobalValues,
     gaugeAuthorities,
     gaugeBlockHeight,
@@ -37,12 +39,73 @@ import { gaugeKeyActivationBroadcast } from '../metrics/chainflip/gaugeKeyActiva
 import { ProtocolData } from '../utils/utils';
 import { gaugeOpenElections } from '../metrics/chainflip/gaugeOpenElections';
 import { gaugeSafeMode } from '../metrics/chainflip/gaugeSafeMode';
+import { BlockQueue } from '../utils/blockQueue';
 
 const metricFailureName: string = 'metric_scrape_failure';
 const metricFailure: promClient.Gauge = new promClient.Gauge({
     name: metricFailureName,
     help: 'Metric is failing to report',
     labelNames: ['metric'],
+    registers: [],
+});
+
+const metricQueueDepthName: string = 'cf_exporter_block_queue_depth';
+const metricQueueDepth: promClient.Gauge = new promClient.Gauge({
+    name: metricQueueDepthName,
+    help: 'Number of finalized blocks waiting to be processed by the exporter',
+    registers: [],
+});
+
+const metricBlocksDroppedName: string = 'cf_exporter_blocks_dropped_total';
+const metricBlocksDropped: promClient.Gauge = new promClient.Gauge({
+    name: metricBlocksDroppedName,
+    help: 'Finalized blocks dropped because the exporter fell too far behind (events for those blocks were not processed)',
+    registers: [],
+});
+
+const metricBlockLagName: string = 'cf_exporter_block_lag';
+const metricBlockLag: promClient.Gauge = new promClient.Gauge({
+    name: metricBlockLagName,
+    help: 'Distance between the latest finalized head and the last block processed by the exporter',
+    registers: [],
+});
+
+const metricProcessingDurationName: string = 'cf_exporter_block_processing_duration_ms';
+const metricProcessingDuration: promClient.Gauge = new promClient.Gauge({
+    name: metricProcessingDurationName,
+    help: 'Wall time spent processing the last block, in milliseconds',
+    registers: [],
+});
+
+const metricProcessingDurationHistName: string =
+    'cf_exporter_block_processing_duration_ms_histogram';
+const metricProcessingDurationHist: promClient.Histogram = new promClient.Histogram({
+    name: metricProcessingDurationHistName,
+    help: 'Distribution of per-block processing wall time, in milliseconds',
+    buckets: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 15000, 20000, 30000],
+    registers: [],
+});
+
+const metricLaneADurationHistName: string = 'cf_exporter_event_metrics_duration_ms_histogram';
+const metricLaneADurationHist: promClient.Histogram = new promClient.Histogram({
+    name: metricLaneADurationHistName,
+    help: 'Distribution of the per-block event-metrics (lane A) wall time, in milliseconds',
+    buckets: [250, 500, 1000, 1500, 2000, 3000, 4000, 6000, 10000],
+    registers: [],
+});
+
+const metricLaneBDurationHistName: string = 'cf_exporter_state_metrics_duration_ms_histogram';
+const metricLaneBDurationHist: promClient.Histogram = new promClient.Histogram({
+    name: metricLaneBDurationHistName,
+    help: 'Distribution of the latest-state-metrics (lane B) wall time, in milliseconds',
+    buckets: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 15000, 20000, 30000],
+    registers: [],
+});
+
+const metricLaneBSkippedName: string = 'cf_exporter_state_metrics_skipped_total';
+const metricLaneBSkipped: promClient.Gauge = new promClient.Gauge({
+    name: metricLaneBSkippedName,
+    help: 'Times the latest-state metrics were skipped for a block because the exporter was catching up',
     registers: [],
 });
 
@@ -59,10 +122,75 @@ export default async (context: Context): Promise<void> => {
     startWatcher(context);
 };
 
+// Lane A: the strict per-block lane. Runs for EVERY finalized block, in order.
+// Two kinds of metrics live here: (1) event/extrinsic-derived metrics that
+// must see every block, and (2) pure monitoring_data reads (no extra RPC)
+// whose values stay valid when processed in order, even if delayed — they
+// keep converging toward the head while catching up instead of freezing.
+async function runLaneA(context: Context, data: ProtocolData): Promise<void> {
+    // Sets the globals (epochIndex, currentBlock, currentAuthorities,
+    // rotationInProgress, agg keys) that the gauges below read for this block.
+    gatherGlobalValues(data);
+
+    await Promise.allSettled([
+        gaugeRotationDuration(context, data),
+        countEvents(context, data),
+        gaugeBlockHeight(context, data),
+        gaugeExternalChainsBlockHeight(context, data),
+        gaugeSolanaNonces(context, data),
+    ]);
+}
+
+// Lane B: latest-state metrics. Only runs when the block just processed is the
+// freshest finalized head; while catching up these are skipped — reporting
+// state for old blocks has no value, the next caught-up block refreshes them.
+async function runLaneB(context: Context, data: ProtocolData): Promise<void> {
+    // priceDelta populates global.prices, read by oraclePrices, which populates
+    // global.oraclePrices, read by elections/lending — hence the chain.
+    const priceChain = (async () => {
+        await gaugePriceDelta(context, data);
+        await gaugeOraclePrices(context, data);
+        await Promise.allSettled([gaugeElections(context, data), gaugeLending(context, data)]);
+    })();
+
+    await Promise.allSettled([
+        priceChain,
+        gaugeAuthorities(context, data),
+        gaugeEpoch(context, data),
+        gaugeSuspendedValidator(context, data),
+        gaugeFlipTotalSupply(context, data),
+        gaugeBtcUtxos(context, data),
+        gaugePendingRedemptions(context, data),
+        gaugePendingBroadcast(context, data),
+        gaugeTssRetryQueues(context, data),
+        gaugeSwappingQueue(context, data),
+        gaugeFeeDeficit(context, data),
+        gaugeDepositChannels(context, data),
+        gaugeKeyActivationBroadcast(context, data),
+        // witness gauges are heavy (per-hash RPCs); their maps tolerate gaps,
+        // so skipping them while catching up is acceptable
+        gaugeWitnessChainTracking(context, data),
+        gaugeWitnessCount(context, data),
+        gaugeValidatorStatus(context, data),
+        gaugeDelegation(context, data),
+        gaugeSafeMode(context, data),
+        gaugeOpenElections(context, data),
+        gaugeBlockWeight(context, data),
+        gaugeBuildVersion(context, data),
+    ]);
+}
+
 async function startWatcher(context: Context) {
     const { logger, env, registry } = context;
     context = { ...context, metricFailure };
     global.rotationInProgress = false;
+    // A restart may have skipped blocks: cumulative event counters would
+    // silently under-count, so every watcher generation starts from a clean,
+    // fully re-seeded zero baseline instead (PromQL increase()/rate() treat
+    // the value drop as a counter reset). No-op on the first start.
+    resetEventCountMetrics(context.config as FlipConfig);
+    metricBlocksDropped.set(0);
+    metricLaneBSkipped.set(0);
     const metricName: string = 'cf_watcher_failure';
     // Reuse the already-registered gauge on restart
     const metric: promClient.Gauge =
@@ -75,6 +203,22 @@ async function startWatcher(context: Context) {
     if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
     if (registry.getSingleMetric(metricFailureName) === undefined)
         registry.registerMetric(metricFailure);
+    if (registry.getSingleMetric(metricQueueDepthName) === undefined)
+        registry.registerMetric(metricQueueDepth);
+    if (registry.getSingleMetric(metricBlocksDroppedName) === undefined)
+        registry.registerMetric(metricBlocksDropped);
+    if (registry.getSingleMetric(metricBlockLagName) === undefined)
+        registry.registerMetric(metricBlockLag);
+    if (registry.getSingleMetric(metricProcessingDurationName) === undefined)
+        registry.registerMetric(metricProcessingDuration);
+    if (registry.getSingleMetric(metricProcessingDurationHistName) === undefined)
+        registry.registerMetric(metricProcessingDurationHist);
+    if (registry.getSingleMetric(metricLaneADurationHistName) === undefined)
+        registry.registerMetric(metricLaneADurationHist);
+    if (registry.getSingleMetric(metricLaneBDurationHistName) === undefined)
+        registry.registerMetric(metricLaneBDurationHist);
+    if (registry.getSingleMetric(metricLaneBSkippedName) === undefined)
+        registry.registerMetric(metricLaneBSkipped);
     global.currentBlock = 0;
     global.prices = new Map();
 
@@ -85,15 +229,33 @@ async function startWatcher(context: Context) {
     const STALL_TIMEOUT_MS = 120_000; // ~20 finalized blocks
     const RESTART_DELAY_MS = 5_000;
     const WATCHDOG_INTERVAL_MS = 15_000;
+    // The worker has its own liveness check: heads arriving but no block completing
+    // means the pipeline is wedged on something the per-request timeouts didn't catch.
+    const WORKER_STALL_TIMEOUT_MS = 300_000;
+    // Bound on the catch-up backlog: ~10 minutes of chain at 6s/block. Beyond this
+    // the oldest blocks are dropped (loudly, via cf_exporter_blocks_dropped_total) —
+    // staying alive and current beats replaying arbitrarily old history.
+    const BLOCK_QUEUE_CAPACITY = 100;
     // rpc-core memoizes a registry lookup per block hash with no eviction (one entry
     // per finalized block, kept forever — see RpcCore.setRegistrySwap). Re-arming the
     // swap every N blocks replaces the memoized function and drops the stale cache.
     const REGISTRY_SWAP_RESET_BLOCKS = 100;
     let stopped = false;
     let lastHeadAt = Date.now();
+    let lastBlockProcessedAt = Date.now();
     let watchdog: ReturnType<typeof setInterval> | undefined;
     let unsubscribe: (() => void) | undefined;
     let api: any;
+
+    const queue = new BlockQueue({
+        capacity: BLOCK_QUEUE_CAPACITY,
+        onDrop: (count, fromBlock, toBlock) => {
+            metricBlocksDropped.inc(count);
+            logger.warn(
+                `Exporter more than ${BLOCK_QUEUE_CAPACITY} blocks behind: dropping blocks ${fromBlock}..${toBlock} (${count})`,
+            );
+        },
+    });
 
     const restart = (reason: string) => {
         if (stopped) return;
@@ -101,6 +263,7 @@ async function startWatcher(context: Context) {
         metric.set(1);
         logger.error(`Chainflip watcher restarting in ${RESTART_DELAY_MS / 1000}s: ${reason}`);
         if (watchdog) clearInterval(watchdog);
+        queue.stop(); // wakes the worker so it can observe `stopped` and exit
         try {
             unsubscribe?.();
         } catch (e) {
@@ -115,6 +278,77 @@ async function startWatcher(context: Context) {
         setTimeout(() => {
             void startWatcher(context);
         }, RESTART_DELAY_MS);
+    };
+
+    // Processes one block at a time, in order: this single awaited pipeline is the
+    // backpressure — when upstream is slow, blocks accumulate as two integers in the
+    // queue instead of as concurrent pipelines on the heap.
+    const runWorker = async () => {
+        // queue.stop() is invoked by restart(), which is the only place that
+        // also sets `stopped` — the queue state is the loop's exit signal.
+        while (!queue.isStopped) {
+            const blockNumber = queue.take();
+            if (blockNumber === undefined) {
+                await queue.waitForBlock();
+                continue;
+            }
+            const startedAt = Date.now();
+            try {
+                const blockHash = (await api.rpc.chain.getBlockHash(blockNumber)).toJSON();
+                logger.info(`finalized_block_stream`, { blockNumber, blockHash });
+                const stateChainData = await makeRpcRequest(api, 'monitoring_data', blockHash);
+                const blockApi = await api.at(blockHash);
+                const data: ProtocolData = {
+                    blockNumber,
+                    blockHash,
+                    data: stateChainData,
+                    blockApi,
+                    signedBlock: null,
+                };
+
+                const laneAStartedAt = Date.now();
+                await runLaneA(context, data);
+                metricLaneADurationHist.observe(Date.now() - laneAStartedAt);
+
+                // Lane B only runs when this block is still the freshest head
+                // (re-checked after lane A so heads that arrived meanwhile defer it).
+                if (queue.depth === 0) {
+                    // the signed block is only consumed by lane B (witness gauges):
+                    // blocks processed during catch-up skip this fetch entirely
+                    const laneBStartedAt = Date.now();
+                    data.signedBlock = await api.rpc.chain.getBlock(blockHash);
+                    await runLaneB(context, data);
+                    metricLaneBDurationHist.observe(Date.now() - laneBStartedAt);
+                } else {
+                    metricLaneBSkipped.inc();
+                    logger.debug(`Skipping latest-state metrics while catching up`, {
+                        blockNumber,
+                        behindBy: queue.depth,
+                    });
+                }
+
+                if (blockNumber % REGISTRY_SWAP_RESET_BLOCKS === 0) {
+                    api._rpcCore.setRegistrySwap((hash: Uint8Array) => api.getBlockRegistry(hash));
+                }
+
+                metricFailure.labels('cf_exporter_block_processing').set(0);
+                metric.set(0);
+            } catch (e) {
+                // A single bad block must not kill the worker: log it and carry on
+                // to the next finalized head.
+                logger.error(
+                    `Failed to process block ${blockNumber}: ${e instanceof Error ? e.stack : e}`,
+                );
+                metricFailure.labels('cf_exporter_block_processing').set(1);
+            } finally {
+                lastBlockProcessedAt = Date.now();
+                metricQueueDepth.set(queue.depth);
+                metricBlockLag.set(Math.max(0, (queue.latestHead ?? blockNumber) - blockNumber));
+                const elapsedMs = Date.now() - startedAt;
+                metricProcessingDuration.set(elapsedMs);
+                metricProcessingDurationHist.observe(elapsedMs);
+            }
+        }
     };
 
     try {
@@ -135,82 +369,33 @@ async function startWatcher(context: Context) {
         context.apiLatest = api;
         api.on('error', (err: any) => logger.error(`api error ${err}`));
 
-        unsubscribe = await api.rpc.chain.subscribeFinalizedHeads(async (header: any) => {
+        // The callback stays synchronous and allocation-free: all per-block work
+        // happens in the worker, which pulls block numbers off the queue in order.
+        unsubscribe = await api.rpc.chain.subscribeFinalizedHeads((header: any) => {
             if (stopped) return; // ignore late deliveries arriving during teardown
-            try {
-                const blockNumber = header.toJSON().number;
-                const blockHash = (await api.rpc.chain.getBlockHash(blockNumber)).toJSON();
-                logger.info(`finalized_block_stream`, {
-                    blockNumber,
-                    blockHash,
-                });
-                const stateChainData = await makeRpcRequest(api, 'monitoring_data', blockHash);
-
-                const blockApi = await api.at(blockHash);
-                // fetched once and shared: several metrics need the full signed block
-                const signedBlock = await api.rpc.chain.getBlock(blockHash);
-                const data: ProtocolData = {
-                    blockNumber,
-                    blockHash,
-                    data: stateChainData,
-                    blockApi,
-                    signedBlock,
-                };
-                gatherGlobalValues(data);
-                gaugeBlockHeight(context, data);
-                gaugeAuthorities(context, data);
-                gaugeExternalChainsBlockHeight(context, data);
-                gaugeEpoch(context, data);
-                gaugeSuspendedValidator(context, data);
-                gaugeFlipTotalSupply(context, data);
-                gaugeRotationDuration(context, data);
-                gaugeBtcUtxos(context, data);
-                gaugePendingRedemptions(context, data);
-                gaugePendingBroadcast(context, data);
-                gaugeTssRetryQueues(context, data);
-                gaugeSwappingQueue(context, data);
-                gaugeFeeDeficit(context, data);
-                gaugeDepositChannels(context, data);
-                gaugeKeyActivationBroadcast(context, data);
-                gaugeSolanaNonces(context, data);
-
-                gaugeDelegation(context, data);
-                gaugeSafeMode(context, data);
-                gaugeOpenElections(context, data);
-                gaugeBlockWeight(context, data);
-                countEvents(context, data);
-                gaugeWitnessChainTracking(context, data);
-                gaugeWitnessCount(context, data);
-                gaugeValidatorStatus(context, data);
-                gaugeBuildVersion(context, data);
-                gaugePriceDelta(context, data);
-                gaugeOraclePrices(context, data);
-                gaugeElections(context, data);
-                gaugeLending(context, data);
-
-                if (blockNumber % REGISTRY_SWAP_RESET_BLOCKS === 0) {
-                    api._rpcCore.setRegistrySwap((hash: Uint8Array) => api.getBlockRegistry(hash));
-                }
-
-                lastHeadAt = Date.now();
-                metricFailure.labels('cf_exporter_block_processing').set(0);
-                metric.set(0);
-            } catch (e) {
-                // A single bad block must not kill the subscription or surface as an
-                // unhandled rejection: log it and carry on to the next finalized head.
-                logger.error(
-                    `Failed to process finalized head: ${e instanceof Error ? e.stack : e}`,
-                );
-                metricFailure.labels('cf_exporter_block_processing').set(1);
-            }
+            lastHeadAt = Date.now();
+            queue.pushHead(header.toJSON().number);
+            metricQueueDepth.set(queue.depth);
         });
 
+        void runWorker();
+
         lastHeadAt = Date.now();
+        lastBlockProcessedAt = Date.now();
         watchdog = setInterval(() => {
             if (stopped) return;
             const sinceLastHead = Date.now() - lastHeadAt;
             if (sinceLastHead > STALL_TIMEOUT_MS) {
-                restart(`no finalized head processed for ${Math.round(sinceLastHead / 1000)}s`);
+                restart(`no finalized head received for ${Math.round(sinceLastHead / 1000)}s`);
+                return;
+            }
+            const sinceLastBlock = Date.now() - lastBlockProcessedAt;
+            if (queue.depth > 0 && sinceLastBlock > WORKER_STALL_TIMEOUT_MS) {
+                restart(
+                    `worker stalled: ${
+                        queue.depth
+                    } blocks queued, no block processed for ${Math.round(sinceLastBlock / 1000)}s`,
+                );
             }
         }, WATCHDOG_INTERVAL_MS);
     } catch (e) {

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -63,13 +63,6 @@ const metricBlocksDropped: promClient.Gauge = new promClient.Gauge({
     registers: [],
 });
 
-const metricBlockLagName: string = 'cf_exporter_block_lag';
-const metricBlockLag: promClient.Gauge = new promClient.Gauge({
-    name: metricBlockLagName,
-    help: 'Distance between the latest finalized head and the last block processed by the exporter',
-    registers: [],
-});
-
 const metricProcessingDurationName: string = 'cf_exporter_block_processing_duration_ms';
 const metricProcessingDuration: promClient.Gauge = new promClient.Gauge({
     name: metricProcessingDurationName,
@@ -189,8 +182,6 @@ async function startWatcher(context: Context) {
     // fully re-seeded zero baseline instead (PromQL increase()/rate() treat
     // the value drop as a counter reset). No-op on the first start.
     resetEventCountMetrics(context.config as FlipConfig);
-    metricBlocksDropped.set(0);
-    metricLaneBSkipped.set(0);
     const metricName: string = 'cf_watcher_failure';
     // Reuse the already-registered gauge on restart
     const metric: promClient.Gauge =
@@ -207,8 +198,6 @@ async function startWatcher(context: Context) {
         registry.registerMetric(metricQueueDepth);
     if (registry.getSingleMetric(metricBlocksDroppedName) === undefined)
         registry.registerMetric(metricBlocksDropped);
-    if (registry.getSingleMetric(metricBlockLagName) === undefined)
-        registry.registerMetric(metricBlockLag);
     if (registry.getSingleMetric(metricProcessingDurationName) === undefined)
         registry.registerMetric(metricProcessingDuration);
     if (registry.getSingleMetric(metricProcessingDurationHistName) === undefined)
@@ -343,7 +332,6 @@ async function startWatcher(context: Context) {
             } finally {
                 lastBlockProcessedAt = Date.now();
                 metricQueueDepth.set(queue.depth);
-                metricBlockLag.set(Math.max(0, (queue.latestHead ?? blockNumber) - blockNumber));
                 const elapsedMs = Date.now() - startedAt;
                 metricProcessingDuration.set(elapsedMs);
                 metricProcessingDurationHist.observe(elapsedMs);


### PR DESCRIPTION
Process block by block sequentially, one at a time, if the watcher falls behind only relevant metrics will be scraped for old blocks (i.e. events), this is to speed up recovery.
This should limit the amount of concurrent requests and improve the exporter stability even when the cf rpc node is slow.