### PR TITLE
feat: Debug heap limit reached

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/app.ts",
   "scripts": {
-    "start": "node --heapsnapshot-near-heap-limit=2 dist/src/app.js",
+    "start": "node --diagnostic-dir=\"${HEAPSNAPSHOT_DIR:-.}\" --heapsnapshot-near-heap-limit=2 dist/src/app.js",
     "build": "tsc",
     "lint": "eslint ./src*",
     "prettier": "pnpm exec prettier --write src/**/*.ts src/*.ts src/**/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/app.ts",
   "scripts": {
-    "start": "node --diagnostic-dir=\"${HEAPSNAPSHOT_DIR:-.}\" --heapsnapshot-near-heap-limit=2 dist/src/app.js",
+    "start": "node dist/src/app.js",
     "build": "tsc",
     "lint": "eslint ./src*",
     "prettier": "pnpm exec prettier --write src/**/*.ts src/*.ts src/**/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/app.ts",
   "scripts": {
-    "start": "node dist/src/app.js",
+    "start": "node --heapsnapshot-near-heap-limit=2 dist/src/app.js",
     "build": "tsc",
     "lint": "eslint ./src*",
     "prettier": "pnpm exec prettier --write src/**/*.ts src/*.ts src/**/**/*.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -68,6 +68,13 @@ tronRegistry.setDefaultLabels({
     network: config.tron.network,
 });
 
+// Process-level Node.js metrics (heap, rss, GC duration, event-loop lag) for leak
+// diagnosis. Kept on its own registry so the nodejs_*/process_* series aren't tagged
+// with a per-chain label. collectDefaultMetrics registers process-global state, so it
+// must be called exactly once.
+const processRegistry = new promClient.Registry();
+promClient.collectDefaultMetrics({ register: processRegistry });
+
 app.listen(env.NETWORK_EXPORTER_PORT || 9000, () => {
     logger.info(`Network Prometheus Exporter started on port ${env.NETWORK_EXPORTER_PORT}`);
 
@@ -171,7 +178,8 @@ app.get('/metrics', async (req, res) => {
             (await arbitrumRegistry.metrics()) +
             (await solanaRegistry.metrics()) +
             (await assetHubRegistry.metrics()) +
-            (await tronRegistry.metrics()),
+            (await tronRegistry.metrics()) +
+            (await processRegistry.metrics()),
     );
 });
 

--- a/src/metrics/chainflip/gaugeWitnessChainTracking.ts
+++ b/src/metrics/chainflip/gaugeWitnessChainTracking.ts
@@ -5,22 +5,12 @@ import { hex2bin, insertOrReplace, logStructureSize, ProtocolData } from '../../
 import makeRpcRequest from '../../utils/makeRpcRequest';
 
 const witnessHash10 = new Map<number, Set<string>>();
-const witnessHash50 = new Map<number, Set<string>>();
-const toDelete = new Map<string, number>();
 
 const metricName: string = 'cf_chain_tracking_witness_count';
 const metric: Gauge = new promClient.Gauge({
     name: metricName,
     help: 'Number of validator witnessing ChainStateUpdated for an external chain',
     labelNames: ['extrinsic', 'marginBlocks'],
-    registers: [],
-});
-
-const metricFailureName: string = 'cf_chain_tracking_witness_failure';
-const metricWitnessFailure: Gauge = new promClient.Gauge({
-    name: metricFailureName,
-    help: 'If 1 the number of witnesses is low, you can find the failing validators in the label `failing_validators`',
-    labelNames: ['extrinsic', 'failing_validators', 'witnessed_by'],
     registers: [],
 });
 
@@ -37,8 +27,6 @@ export const gaugeWitnessChainTracking = async (
 
         try {
             if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
-            if (registry.getSingleMetric(metricFailureName) === undefined)
-                registry.registerMetric(metricWitnessFailure);
 
             const signedBlock = data.signedBlock;
             const currentBlockNumber = data.blockNumber;
@@ -49,21 +37,6 @@ export const gaugeWitnessChainTracking = async (
                 currentBlockNumber,
                 { everyBlocks: 50 },
             );
-            logStructureSize(
-                logger,
-                'witnessChainTracking.witnessHash50',
-                witnessHash50.size,
-                currentBlockNumber,
-                { everyBlocks: 50 },
-            );
-            logStructureSize(
-                logger,
-                'witnessChainTracking.toDelete',
-                toDelete.size,
-                currentBlockNumber,
-                { everyBlocks: 50 },
-            );
-            deleteOldHashes(currentBlockNumber);
             await processHash10(
                 currentBlockNumber,
                 apiLatest,
@@ -71,7 +44,6 @@ export const gaugeWitnessChainTracking = async (
                 data.blockHash,
                 data.blockApi,
             );
-            await processHash50(currentBlockNumber, logger, data.blockApi);
             let ethBlock = 0;
             let arbBlock = 0;
             let hubBlock = 0;
@@ -113,16 +85,6 @@ export const gaugeWitnessChainTracking = async (
     }
 };
 
-function deleteOldHashes(currentBlockNumber: number) {
-    toDelete.forEach((block, labels) => {
-        if (block <= currentBlockNumber) {
-            const values = JSON.parse(labels);
-            metricWitnessFailure.remove(values.extrinsic, values.validators, values.witnessedBy);
-            toDelete.delete(labels);
-        }
-    });
-}
-
 function ethereumChainTracking(
     callData: any,
     blockNumber: number,
@@ -145,15 +107,6 @@ function ethereumChainTracking(
     if (Number(blockHeight) > ethBlock) {
         insertOrReplace(
             witnessHash10,
-            JSON.stringify({
-                type: `${callData.section}:${callData.method}`,
-                hash: blakeHash,
-            }),
-            blockNumber,
-            `${callData.section}:${callData.method}`,
-        );
-        insertOrReplace(
-            witnessHash50,
             JSON.stringify({
                 type: `${callData.section}:${callData.method}`,
                 hash: blakeHash,
@@ -191,15 +144,6 @@ function assetHubChainTracking(
     if (Number(blockHeight) > hubBlock) {
         insertOrReplace(
             witnessHash10,
-            JSON.stringify({
-                type: `${callData.section}:${callData.method}`,
-                hash: blakeHash,
-            }),
-            blockNumber,
-            `${callData.section}:${callData.method}`,
-        );
-        insertOrReplace(
-            witnessHash50,
             JSON.stringify({
                 type: `${callData.section}:${callData.method}`,
                 hash: blakeHash,
@@ -245,15 +189,6 @@ function arbitrumChainTracking(
             blockNumber,
             `${callData.section}:${callData.method}`,
         );
-        insertOrReplace(
-            witnessHash50,
-            JSON.stringify({
-                type: `${callData.section}:${callData.method}`,
-                hash: blakeHash,
-            }),
-            blockNumber,
-            `${callData.section}:${callData.method}`,
-        );
         return Number(blockHeight || 0);
     }
     return arbBlock;
@@ -283,43 +218,7 @@ async function processHash10(
                     metric.labels(parsedObj.type, '10').set(total);
                 }
                 // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                if (result && total > 0)
-                    log(total, result, currentBlockNumber, blockNumber, parsedObj, logger);
-            }
-        }
-    }
-}
-
-async function processHash50(currentBlockNumber: number, logger: any, blockApi: any) {
-    for (const [blockNumber, set] of witnessHash50) {
-        if (currentBlockNumber - blockNumber > 50) {
-            const tmpSet = new Set(set);
-            witnessHash50.delete(blockNumber);
-            for (const hash of tmpSet) {
-                const parsedObj = JSON.parse(hash);
-                try {
-                    const votes: { toJSON: () => any } = await blockApi.query.witnesser.votes(
-                        global.epochIndex,
-                        parsedObj.hash,
-                    );
-                    if (global.currentBlock === currentBlockNumber) {
-                        const vote = votes.toJSON();
-                        if (vote) {
-                            const binary = hex2bin(vote);
-                            const number = binary.match(/1/g)?.length || 0;
-
-                            metric.labels(parsedObj.type, '50').set(number);
-                            // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                            if (number < global.currentAuthorities) {
-                                logger.info(
-                                    `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnessed by ${number} validators after 50 blocks!`,
-                                );
-                            }
-                        }
-                    }
-                } catch (err) {
-                    logger.warn(`Promise rejected ${err}`);
-                }
+                if (result && total > 0) log(total, result, blockNumber, parsedObj, logger);
             }
         }
     }
@@ -357,14 +256,7 @@ async function countWitnesses(
     return [result, total];
 }
 
-function log(
-    total: number,
-    result: any,
-    currentBlockNumber: number,
-    blockNumber: number,
-    parsedObj: any,
-    logger: any,
-) {
+function log(total: number, result: any, blockNumber: number, parsedObj: any, logger: any) {
     if (total < global.currentAuthorities) {
         const validators: string[] = [];
         result.validators.forEach(([ss58address, vanity, witness]: [string, string, boolean]) => {
@@ -376,18 +268,5 @@ function log(
             `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnessed by ${total} validators after 10 blocks!
             Failing validators: [${validators}]`,
         );
-        // in case less than 90% witnessed it
-        // create a temporary metric so that we can fetch the list of validators in our alerting system
-        if (total <= global.currentAuthorities * 0.9) {
-            metricWitnessFailure.labels(`${parsedObj.type}`, `${validators}`, `${total}`).set(1);
-            toDelete.set(
-                JSON.stringify({
-                    extrinsic: `${parsedObj.type}`,
-                    validators: `${validators}`,
-                    witnessedBy: `${total}`,
-                }),
-                currentBlockNumber + 40,
-            );
-        }
     }
 }

--- a/src/metrics/chainflip/gaugeWitnessCount.ts
+++ b/src/metrics/chainflip/gaugeWitnessCount.ts
@@ -4,22 +4,12 @@ import { hex2bin, insertOrReplace, logStructureSize, ProtocolData } from '../../
 import makeRpcRequest from '../../utils/makeRpcRequest';
 
 const witnessExtrinsicHash10 = new Map<number, Set<string>>();
-const witnessExtrinsicHash50 = new Map<number, Set<string>>();
-const toDelete = new Map<string, number>();
 
 const metricName: string = 'cf_witness_count';
 const metric: Gauge = new promClient.Gauge({
     name: metricName,
     help: 'Number of validator witnessing an extrinsic',
     labelNames: ['extrinsic', 'marginBlocks'],
-    registers: [],
-});
-
-const metricFailureName: string = 'cf_witness_count_failure';
-const metricWitnessFailure: Gauge = new promClient.Gauge({
-    name: metricFailureName,
-    help: 'If 1 the number of witnesses is low, you can find the failing validators in the label `failing_validators`',
-    labelNames: ['extrinsic', 'failing_validators', 'witnessed_by'],
     registers: [],
 });
 
@@ -33,8 +23,6 @@ export const gaugeWitnessCount = async (context: Context, data: ProtocolData): P
 
         try {
             if (registry.getSingleMetric(metricName) === undefined) registry.registerMetric(metric);
-            if (registry.getSingleMetric(metricFailureName) === undefined)
-                registry.registerMetric(metricWitnessFailure);
 
             const signedBlock = data.signedBlock;
             const currentBlockNumber = data.blockNumber;
@@ -45,17 +33,6 @@ export const gaugeWitnessCount = async (context: Context, data: ProtocolData): P
                 currentBlockNumber,
                 { everyBlocks: 50 },
             );
-            logStructureSize(
-                logger,
-                'witnessCount.witnessExtrinsicHash50',
-                witnessExtrinsicHash50.size,
-                currentBlockNumber,
-                { everyBlocks: 50 },
-            );
-            logStructureSize(logger, 'witnessCount.toDelete', toDelete.size, currentBlockNumber, {
-                everyBlocks: 50,
-            });
-            deleteOldHashes(currentBlockNumber);
             await processHash10(
                 currentBlockNumber,
                 apiLatest,
@@ -63,7 +40,6 @@ export const gaugeWitnessCount = async (context: Context, data: ProtocolData): P
                 data.blockHash,
                 data.blockApi,
             );
-            await processHash50(currentBlockNumber, logger, data.blockApi);
             // chech the witnessAtEpoch extrinsics in a block and save the encoded callHash to check later
             signedBlock.block.extrinsics.forEach((ex: any, index: any) => {
                 if (ex.toHuman().method.method === 'witnessAtEpoch') {
@@ -72,15 +48,6 @@ export const gaugeWitnessCount = async (context: Context, data: ProtocolData): P
                         const hashToCheck = ex.method.args[0].hash.toHex();
                         insertOrReplace(
                             witnessExtrinsicHash10,
-                            JSON.stringify({
-                                type: `${callData.section}:${callData.method}`,
-                                hash: hashToCheck,
-                            }),
-                            currentBlockNumber,
-                            ``,
-                        );
-                        insertOrReplace(
-                            witnessExtrinsicHash50,
                             JSON.stringify({
                                 type: `${callData.section}:${callData.method}`,
                                 hash: hashToCheck,
@@ -98,16 +65,6 @@ export const gaugeWitnessCount = async (context: Context, data: ProtocolData): P
         }
     }
 };
-
-function deleteOldHashes(currentBlockNumber: number) {
-    toDelete.forEach((block, labels) => {
-        if (block <= currentBlockNumber) {
-            const values = JSON.parse(labels);
-            metricWitnessFailure.remove(values.extrinsic, values.validators, values.witnessedBy);
-            toDelete.delete(labels);
-        }
-    });
-}
 
 async function processHash10(
     currentBlockNumber: number,
@@ -133,8 +90,7 @@ async function processHash10(
                     metric.labels(parsedObj.type, '10').set(total);
                 }
                 // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                if (result && total > 0)
-                    log(total, result, currentBlockNumber, blockNumber, parsedObj, logger);
+                if (result && total > 0) log(total, result, blockNumber, parsedObj, logger);
             }
         }
     }
@@ -172,14 +128,7 @@ async function countWitnesses(
     return [result, total];
 }
 
-function log(
-    total: number,
-    result: any,
-    currentBlockNumber: number,
-    blockNumber: number,
-    parsedObj: any,
-    logger: any,
-) {
+function log(total: number, result: any, blockNumber: number, parsedObj: any, logger: any) {
     if (total < global.currentAuthorities) {
         const validators: string[] = [];
         result.validators.forEach(([ss58address, vanity, witness]: [string, string, boolean]) => {
@@ -191,53 +140,5 @@ function log(
             `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnessed by ${total} validators after 10 blocks!
             Failing validators: [${validators}]`,
         );
-        // in case less than 90% witnessed it
-        // create a temporary metric so that we can fetch the list of validators in our alerting system
-        if (total <= global.currentAuthorities * 0.9) {
-            metricWitnessFailure.labels(`${parsedObj.type}`, `${validators}`, `${total}`).set(1);
-            toDelete.set(
-                JSON.stringify({
-                    extrinsic: `${parsedObj.type}`,
-                    validators: `${validators}`,
-                    witnessedBy: `${total}`,
-                }),
-                currentBlockNumber + 40,
-            );
-        }
-    }
-}
-
-async function processHash50(currentBlockNumber: number, logger: any, blockApi: any) {
-    for (const [blockNumber, set] of witnessExtrinsicHash50) {
-        if (currentBlockNumber - blockNumber > 50) {
-            const tmpSet = new Set(set);
-            witnessExtrinsicHash50.delete(blockNumber);
-            for (const hash of tmpSet) {
-                const parsedObj = JSON.parse(hash);
-                try {
-                    const votes: { toJSON: () => any } = await blockApi.query.witnesser.votes(
-                        global.epochIndex,
-                        parsedObj.hash,
-                    );
-                    if (global.currentBlock === currentBlockNumber) {
-                        const vote = votes.toJSON();
-                        if (vote) {
-                            const binary = hex2bin(vote);
-                            const number = binary.match(/1/g)?.length || 0;
-
-                            metric.labels(parsedObj.type, '50').set(number);
-                            // log the hash if not all the validator witnessed it so we can quickly look up the hash and check which validator failed to do so
-                            if (number < global.currentAuthorities) {
-                                logger.info(
-                                    `Block ${blockNumber}: ${parsedObj.type} hash ${parsedObj.hash} witnessed by ${number} validators after 50 blocks!`,
-                                );
-                            }
-                        }
-                    }
-                } catch (err) {
-                    logger.warn(`Promise rejected ${err}`);
-                }
-            }
-        }
     }
 }

--- a/src/watchers/assetHub.ts
+++ b/src/watchers/assetHub.ts
@@ -47,7 +47,16 @@ async function startWatcher(context: Context) {
         pollEndpoint(gaugeBlockHeight, context, 6);
         pollEndpoint(gaugeBalance, { ...context }, 6);
 
+        // countEvents calls api.at(blockHash) per finalized block; @polkadot rpc-core
+        // memoizes a registry lookup per hash with no eviction (see chainflip.ts). Re-arm
+        // the swap every N blocks to drop the stale per-hash cache. Mirrors chainflip.
+        const REGISTRY_SWAP_RESET_BLOCKS = 100;
         await api.rpc.chain.subscribeFinalizedHeads(async (header) => {
+            if (header.number.toNumber() % REGISTRY_SWAP_RESET_BLOCKS === 0) {
+                (api as any)._rpcCore.setRegistrySwap(async (hash: Uint8Array) => {
+                    return await api.getBlockRegistry(hash);
+                });
+            }
             await countEvents({ ...context, header });
             metric.set(0);
         });

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -285,6 +285,15 @@ async function startWatcher(context: Context) {
             try {
                 const blockHash = (await api.rpc.chain.getBlockHash(blockNumber)).toJSON();
                 logger.info(`finalized_block_stream`, { blockNumber, blockHash });
+                // Leak diagnostics: correlate retained heap with block progress. A steady
+                // monotonic climb here (vs. a sawtooth) confirms per-block retention.
+                const mem = process.memoryUsage();
+                logger.debug(`heap_usage`, {
+                    blockNumber,
+                    heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024),
+                    rssMb: Math.round(mem.rss / 1024 / 1024),
+                    externalMb: Math.round(mem.external / 1024 / 1024),
+                });
                 const stateChainData = await makeRpcRequest(api, 'monitoring_data', blockHash);
                 const blockApi = await api.at(blockHash);
                 const data: ProtocolData = {


### PR DESCRIPTION
Adding a heap dump before nodejs reaches the heap limit and crash.

@francescogionghi @vdoflip 
TODO:
- set `NODE_OPTIONS="--diagnostic-dir=/heapdumps --heapsnapshot-near-heap-limit=2"` 
- and set /heapdumps as a persistent volume, ideally this should be ~4GB so we are sure it can store up to 2 full heap snapshots (~1.5GB each)