### PR TITLE
fix: limit cache to 1 element

### DIFF
--- a/src/watchers/assetHub.ts
+++ b/src/watchers/assetHub.ts
@@ -42,6 +42,8 @@ async function startWatcher(context: Context) {
         const api: ApiPromise = await ApiPromise.create({
             provider,
             noInitWarn: true,
+            // Cap rpc-core's decoded-storage LRU, never used capping it at 1 to avoid a mem leak.
+            rpcCacheCapacity: 1,
         });
         context.api = api;
         pollEndpoint(gaugeBlockHeight, context, 6);

--- a/src/watchers/chainflip.ts
+++ b/src/watchers/chainflip.ts
@@ -362,6 +362,10 @@ async function startWatcher(context: Context) {
             noInitWarn: true,
             types: stateChainTypes as DeepMutable<typeof stateChainTypes>,
             rpc: { ...customRpcs },
+            // rpc-core caches every decoded multi-key storage value in an LRU
+            // (default capacity 102,400) whose TTL refreshes on every block because of an implementation bug.
+            // Capping it at 1 to avoid a mem leak.
+            rpcCacheCapacity: 1,
         });
         context.apiLatest = api;
         api.on('error', (err: any) => logger.error(`api error ${err}`));


### PR DESCRIPTION
Limiting polkajs cache to 1 since we don't use and it is mem leaking because of a bug which makes entry never expire.